### PR TITLE
Fix removal of incubator footer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ import com.typesafe.sbt.packager.docker._
 ThisBuild / versionScheme := Some(VersionScheme.SemVerSpec)
 sourceDistName := "apache-pekko-persistence-cassandra"
 sourceDistIncubating := false
-Global / pekkoParadoxIncubatorNotice := None
 
 val mimaCompareVersion = "1.0.0"
 
@@ -147,7 +146,8 @@ lazy val docs = project
       "javadoc.org.apache.pekko.persistence.cassandra.base_url" -> ""), // no Javadoc is published
     paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
     ApidocPlugin.autoImport.apidocRootPackage := "org.apache.pekko",
-    apidocRootPackage := "org.apache.pekko")
+    apidocRootPackage := "org.apache.pekko",
+    Global / pekkoParadoxIncubatorNotice := None)
 
 Global / onLoad := (Global / onLoad).value.andThen { s =>
   val v = version.value


### PR DESCRIPTION
@pjfanning You need to put the `Global / pekkoParadoxIncubatorNotice` in the `docs` project since that is what generates paradox docs.

I verified that this works locally, you can also use `inspect pekkoParadoxIncubatorNotice` to verify how the settings are being set.