### PR TITLE
Pin Scala 3.3 LTS in scala steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -4,6 +4,8 @@ updates.pin = [
   { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox", version = "0.9." }
   # Pin logback to v1.3.x because v1.4.x needs JDK11
   { groupId = "ch.qos.logback", version="1.3." }
+  # Scala 3.3 is a LTS
+  { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
 ]
 
 updates.ignore = [


### PR DESCRIPTION
I noticed in Scala OS projects that Scala Steward has been bumping 3.3.x to 3.4.x