### PR TITLE
Cache output of assembly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val cassandraLauncher = project
   .settings(
     name := "pekko-persistence-cassandra-launcher",
     Compile / managedResourceDirectories += (cassandraBundle / target).value / "bundle",
-    Compile / managedResources += (cassandraBundle / assembly).value)
+    Compile / managedResources += (cassandraBundle / Compile /  packageBin).value)
 
 // This project doesn't get published directly, rather the assembled artifact is included as part of cassandraLaunchers
 // resources
@@ -62,7 +62,20 @@ lazy val cassandraBundle = project
       .exclude("commons-logging", "commons-logging"),
     dependencyOverrides += "com.github.jbellis" % "jamm" % "0.3.3", // See jamm comment in https://issues.apache.org/jira/browse/CASSANDRA-9608
     assembly / target := target.value / "bundle" / "pekko" / "persistence" / "cassandra" / "launcher",
-    assembly / assemblyJarName := "cassandra-bundle.jar")
+    assembly / assemblyJarName := "cassandra-bundle.jar",
+    Compile / packageBin := Def.taskDyn {
+      val store = streams.value.cacheStoreFactory.make("shaded-output")
+      val uberJarLocation = (assembly / assemblyOutputPath).value
+      val tracker = Tracked.outputChanged(store) { (changed: Boolean, file: File) =>
+        if (changed) {
+          Def.task {
+            (Compile / assembly).value
+          }
+        } else Def.task { file }
+      }
+      tracker(() => uberJarLocation)
+    }.value,
+  )
 
 // Used for testing events by tag in various environments
 lazy val endToEndExample = project

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val cassandraLauncher = project
   .settings(
     name := "pekko-persistence-cassandra-launcher",
     Compile / managedResourceDirectories += (cassandraBundle / target).value / "bundle",
-    Compile / managedResources += (cassandraBundle / Compile /  packageBin).value)
+    Compile / managedResources += (cassandraBundle / Compile / packageBin).value)
 
 // This project doesn't get published directly, rather the assembled artifact is included as part of cassandraLaunchers
 // resources
@@ -74,8 +74,7 @@ lazy val cassandraBundle = project
         } else Def.task { file }
       }
       tracker(() => uberJarLocation)
-    }.value,
-  )
+    }.value)
 
 // Used for testing events by tag in various environments
 lazy val endToEndExample = project


### PR DESCRIPTION
## Motivation

similar to https://github.com/apache/pekko/pull/1125

## Before

<img width="1311" alt="截屏2024-04-12 14 34 38" src="https://github.com/apache/pekko-persistence-cassandra/assets/26020358/f048107c-fe0b-4b33-a120-5770e5229ea2">

## After

<img width="734" alt="截屏2024-04-12 14 33 15" src="https://github.com/apache/pekko-persistence-cassandra/assets/26020358/dbea8457-5f71-437d-a3b9-f4bbf3b1fd62">
