### PR TITLE
Move link validator workflow to scheduled

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -3,7 +3,6 @@ name: Link Validator
 permissions: {}
 
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'


### PR DESCRIPTION
Notifications of failed builds already go to
https://lists.apache.org/list.html?notifications@pekko.apache.org

Related to https://github.com/apache/pekko/issues/1309