### PR TITLE
add sbt-reproducible-builds and fix lanucher builds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val cassandraLauncher = project
   .disablePlugins(MimaPlugin)
   .settings(
     name := "pekko-persistence-cassandra-launcher",
-    Compile / unmanagedResourceDirectories += (cassandraBundle / target).value,
+    Compile / unmanagedResources += (cassandraBundle / target).value,
     Compile / unmanagedResources += (cassandraBundle / Compile / packageBin).value)
 
 // This project doesn't get published directly, rather the assembled artifact is included as part of cassandraLaunchers

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,6 @@ lazy val cassandraLauncher = project
   .disablePlugins(MimaPlugin)
   .settings(
     name := "pekko-persistence-cassandra-launcher",
-    Compile / unmanagedResources += (cassandraBundle / target).value,
     Compile / unmanagedResources += (cassandraBundle / Compile / packageBin).value)
 
 // This project doesn't get published directly, rather the assembled artifact is included as part of cassandraLaunchers

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@
  */
 
 import com.typesafe.sbt.packager.docker._
+import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
 
 ThisBuild / versionScheme := Some(VersionScheme.SemVerSpec)
 sourceDistName := "apache-pekko-persistence-cassandra"
@@ -16,6 +17,8 @@ sourceDistIncubating := false
 val mimaCompareVersion = "1.0.0"
 
 ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
+
+ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 
 lazy val root = project
   .in(file("."))
@@ -29,7 +32,7 @@ dumpSchema := (core / Test / runMain).toTask(" org.apache.pekko.persistence.cass
 
 lazy val core = project
   .in(file("core"))
-  .enablePlugins(Common, AutomateHeaderPlugin, MimaPlugin, MultiJvmPlugin)
+  .enablePlugins(Common, AutomateHeaderPlugin, MimaPlugin, MultiJvmPlugin, ReproducibleBuildsPlugin)
   .dependsOn(cassandraLauncher % Test)
   .settings(
     name := "pekko-persistence-cassandra",
@@ -43,7 +46,7 @@ lazy val core = project
 
 lazy val cassandraLauncher = project
   .in(file("cassandra-launcher"))
-  .enablePlugins(Common)
+  .enablePlugins(Common, ReproducibleBuildsPlugin)
   .disablePlugins(MimaPlugin)
   .settings(
     name := "pekko-persistence-cassandra-launcher",

--- a/build.sbt
+++ b/build.sbt
@@ -50,8 +50,8 @@ lazy val cassandraLauncher = project
   .disablePlugins(MimaPlugin)
   .settings(
     name := "pekko-persistence-cassandra-launcher",
-    Compile / managedResourceDirectories += (cassandraBundle / target).value,
-    Compile / managedResources += (cassandraBundle / Compile / packageBin).value)
+    Compile / unmanagedResourceDirectories += (cassandraBundle / target).value,
+    Compile / unmanagedResources += (cassandraBundle / Compile / packageBin).value)
 
 // This project doesn't get published directly, rather the assembled artifact is included as part of cassandraLaunchers
 // resources

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,6 +18,7 @@ addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.3.3")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.12")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")
+addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32")
 
 // Documentation
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")


### PR DESCRIPTION
Continue on the #205, resolves: #192

Jar results seem the same:

```diff
❯ diff unzip.txt unzip_main.txt
1,2c1,2
< ❯ unzip pekko-persistence-cassandra-launcher_2.13.jar
< Archive:  pekko-persistence-cassandra-launcher_2.13.jar
---
> ❯ unzip pekko-persistence-cassandra-launcher_2.13_main.jar
> Archive:  pekko-persistence-cassandra-launcher_2.13_main.jar
4,6d3
<   inflating: META-INF/LICENSE
<   inflating: META-INF/NOTICE
<   inflating: cassandra-bundle.jar
12a10,12
>   inflating: META-INF/LICENSE
>   inflating: META-INF/NOTICE
>   inflating: cassandra-bundle.jar
```

and the zipdiff report the same result:

```
 java -jar ~/Downloads/zipdiff-0.4/build/zipdiff.jar -file1 ./pekko-persistence-cassandra-launcher_2.13.jar -file2 main/pekko-persistence-cassandra-launcher_2.13_main.jar -outputfile diffs.html
```

<img width="601" alt="截屏2024-06-08 13 04 26" src="https://github.com/apache/pekko-persistence-cassandra/assets/26020358/72a44236-5cd1-4466-be32-87fc6879d22f">

```diff
❯ diff META-INF/MANIFEST.MF main/META-INF/MANIFEST.MF
3c3,5
< Implementation-URL: https://pekko.apache.org/
---
> Implementation-Version: 1.1.0-M0+63-fa9370e2-SNAPSHOT
> Specification-Vendor: Apache Software Foundation
> Specification-Title: pekko-persistence-cassandra-launcher
4a7,8
> Specification-Version: 1.1.0-M0+63-fa9370e2-SNAPSHOT
> Implementation-URL: https://pekko.apache.org/
6d9
< Implementation-Version: 1.1.0-M0+67-c7590392-SNAPSHOT
9,11d11
< Specification-Title: pekko-persistence-cassandra-launcher
< Specification-Vendor: Apache Software Foundation
< Specification-Version: 1.1.0-M0+67-c7590392-SNAPSHOT
```
