### PR TITLE
test with pekko 1.1

### DIFF
--- a/.github/workflows/pekko-1.0-nightly-tests.yml
+++ b/.github/workflows/pekko-1.0-nightly-tests.yml
@@ -1,4 +1,4 @@
-name: Run Tests with Pekko 1.1 builds
+name: Run Tests with Pekko 1.0.x builds
 
 on:
   schedule:
@@ -15,7 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { javaVersion: '8',  container: "cassandra-latest",  scalaVersion: "++2.13", test: "test" }
+          - { javaVersion: '8', container: "cassandra-latest", scalaVersion: "2.12", test: "test" }
+          - { javaVersion: '8', container: "cassandra-latest", scalaVersion: "2.13", test: "test" }
+          - { javaVersion: '8', container: "cassandra-latest", scalaVersion: "3.3", test: "test" }
 
     env:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
@@ -44,4 +46,4 @@ jobs:
 
       - name: Test against ${{ matrix.container }}
         run: |-
-          docker-compose up -d ${{ matrix.container }} && sbt -Dpekko.build.pekko.version=main -Dpekko.build.pekko.connectors.version=main ${{ matrix.scalaVersion }} ${{matrix.test}}
+          docker-compose up -d ${{ matrix.container }} && sbt -Dpekko.build.pekko.version=1.0.x -Dpekko.build.pekko.connectors.version=1.0.x ++${{ matrix.scalaVersion }} ${{matrix.test}}

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/query/EventsByTagSpec.scala
@@ -892,10 +892,8 @@ class EventsByTagLongRefreshIntervalSpec
         probe.request(2)
         // less than the refresh interval, previously this would evaluate the new persistence-id timeout and then not re-evaluate
         // it again until the next refresh interval
-        probe.expectNextWithTimeoutPF(2.seconds,
-          {
-            case EventEnvelope(_, `pid`, 2L, "cat2") =>
-          })
+        val f: PartialFunction[Any, Any] = { case EventEnvelope(_, `pid`, 2L, "cat2") => }
+        probe.expectNextWithTimeoutPF(2.seconds, f)
       })
   }
 }
@@ -1128,7 +1126,8 @@ class EventsByTagSpecBackTrackingLongRefreshInterval
         1,
         bucketSize)
       // much smaller than the refresh interval
-      probe.expectNextWithTimeoutPF(3.seconds, { case e @ EventEnvelope(_, "p1", 1L, "e1") => e })
+      val f: PartialFunction[Any, Any] = { case e @ EventEnvelope(_, "p1", 1L, "e1") => e }
+      probe.expectNextWithTimeoutPF(3.seconds, f)
     }
   }
 

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/query/EventsByTagStageSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/query/EventsByTagStageSpec.scala
@@ -290,8 +290,10 @@ class EventsByTagStageSpec
       val sub = tagStream.runWith(TestSink.probe[EventEnvelope])
 
       sub.request(3)
-      sub.expectNextWithTimeoutPF(waitTime, { case EventEnvelope(_, "p-1", 10, "p1e10") => })
-      sub.expectNextWithTimeoutPF(waitTime, { case EventEnvelope(_, "p-1", 11, "p1e11") => })
+      val f0: PartialFunction[Any, Any] = { case EventEnvelope(_, "p-1", 10, "p1e10") => }
+      val f1: PartialFunction[Any, Any] = { case EventEnvelope(_, "p-1", 11, "p1e11") => }
+      sub.expectNextWithTimeoutPF(waitTime, f0)
+      sub.expectNextWithTimeoutPF(waitTime, f1)
       sub.expectComplete()
     }
 
@@ -542,7 +544,8 @@ class EventsByTagStageSpec
       sub.expectNoMessage(100.millis)
       writeTaggedEvent(nowTime, PersistentRepr("p1e11", 11, "p-1"), Set(tag), 11, bucketSize)
       // wait more than the new persistence id timeout but less than the gap-timeout
-      sub.expectNextWithTimeoutPF(newPersistenceIdTimeout * 1.1, { case EventEnvelope(_, "p-1", 11, "p1e11") => })
+      val f: PartialFunction[Any, Any] = { case EventEnvelope(_, "p-1", 11, "p1e11") => }
+      sub.expectNextWithTimeoutPF(newPersistenceIdTimeout * 1.1, f)
 
       // add more events to check that the periodic poll still works
       writeTaggedEvent(LocalDateTime.now(ZoneOffset.UTC), PersistentRepr("p1e12", 12, "p-1"), Set(tag), 12, bucketSize)

--- a/project/PekkoConnectorsDependency.scala
+++ b/project/PekkoConnectorsDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoConnectorsDependency extends PekkoDependency {
   override val checkProject: String = "pekko-connectors-cassandra"
   override val module: Option[String] = Some("connectors")
-  override val currentVersion: String = "1.0.2"
+  override val currentVersion: String = "1.1.0-M1"
 }

--- a/project/PekkoCoreDependency.scala
+++ b/project/PekkoCoreDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoCoreDependency extends PekkoDependency {
   override val checkProject: String = "pekko-cluster-sharding-typed"
   override val module: Option[String] = None
-  override val currentVersion: String = "1.0.2"
+  override val currentVersion: String = "1.1.0-M1"
 }


### PR DESCRIPTION
* changes main dependency to pekko 1.1 builds
* repurposes the nightly pekko 1.1 job to use pekko 1.0 builds (because all the other builds will now use pekko 1.1 builds)
* test with different scala versions

Got compile issues in Java 11, Scala 2.11 test compilation.
https://github.com/apache/pekko-persistence-cassandra/actions/runs/9907517623/job/27371382362

```
[info] compiling 67 Scala sources to /home/runner/work/pekko-persistence-cassandra/pekko-persistence-cassandra/core/target/scala-2.12/test-classes ...
[error] /home/runner/work/pekko-persistence-cassandra/pekko-persistence-cassandra/core/src/test/scala/org/apache/pekko/persistence/cassandra/query/EventsByTagSpec.scala:896:11: missing parameter type for expanded function
[error] The argument types of an anonymous function must be fully known. (SLS 8.5)
[error] Expected type was: ?
[error]           {
[error]           ^
[error] /home/runner/work/pekko-persistence-cassandra/pekko-persistence-cassandra/core/src/test/scala/org/apache/pekko/persistence/cassandra/query/EventsByTagSpec.scala:1131:48: missing parameter type for expanded function
[error] The argument types of an anonymous function must be fully known. (SLS 8.5)
[error] Expected type was: ?
[error]       probe.expectNextWithTimeoutPF(3.seconds, { case e @ EventEnvelope(_, "p1", 1L, "e1") => e })
[error]                                                ^
[error] /home/runner/work/pekko-persistence-cassandra/pekko-persistence-cassandra/core/src/test/scala/org/apache/pekko/persistence/cassandra/query/EventsByTagStageSpec.scala:293:45: missing parameter type for expanded function
[error] The argument types of an anonymous function must be fully known. (SLS 8.5)
[error] Expected type was: ?
[error]       sub.expectNextWithTimeoutPF(waitTime, { case EventEnvelope(_, "p-1", 10, "p1e10") => })
[error]                                             ^
[error] /home/runner/work/pekko-persistence-cassandra/pekko-persistence-cassandra/core/src/test/scala/org/apache/pekko/persistence/cassandra/query/EventsByTagStageSpec.scala:294:45: missing parameter type for expanded function
[error] The argument types of an anonymous function must be fully known. (SLS 8.5)
[error] Expected type was: ?
[error]       sub.expectNextWithTimeoutPF(waitTime, { case EventEnvelope(_, "p-1", 11, "p1e11") => })
[error]                                             ^
[error] /home/runner/work/pekko-persistence-cassandra/pekko-persistence-cassandra/core/src/test/scala/org/apache/pekko/persistence/cassandra/query/EventsByTagStageSpec.scala:545:[66](https://github.com/apache/pekko-persistence-cassandra/actions/runs/9907517623/job/27371382362#step:6:67): missing parameter type for expanded function
[error] The argument types of an anonymous function must be fully known. (SLS 8.5)
[error] Expected type was: ?
[error]       sub.expectNextWithTimeoutPF(newPersistenceIdTimeout * 1.1, { case EventEnvelope(_, "p-1", 11, "p1e11") => })
[error]
```