### PR TITLE
use max function to improve csql performance

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournalStatements.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournalStatements.scala
@@ -288,11 +288,9 @@ import scala.concurrent.{ ExecutionContext, Future }
 
   def selectHighestSequenceNr =
     s"""
-     SELECT sequence_nr FROM $tableName WHERE
+     SELECT max(sequence_nr) FROM $tableName WHERE
        persistence_id = ? AND
        partition_nr = ?
-       ORDER BY sequence_nr
-       DESC LIMIT 1
    """
 
   def selectDeletedTo =

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournalStatements.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournalStatements.scala
@@ -288,7 +288,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 
   def selectHighestSequenceNr =
     s"""
-     SELECT max(sequence_nr) FROM $tableName WHERE
+     SELECT MAX(sequence_nr) AS sequence_nr FROM $tableName WHERE
        persistence_id = ? AND
        partition_nr = ?
    """


### PR DESCRIPTION
* relates to #240 
* similar to https://github.com/akka/akka-persistence-jdbc/pull/401

The `max` function requires a min of Cassandra 2.2 and we can release note that. https://en.wikipedia.org/wiki/Apache_Cassandra (2.2 was released in 2015)