### PR TITLE
drop scala 2.12

### DIFF
--- a/.github/workflows/pekko-1.0-nightly-tests.yml
+++ b/.github/workflows/pekko-1.0-nightly-tests.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          ref: 1.1.x
 
       - name: Checkout GitHub merge
         if: github.event.pull_request

--- a/.github/workflows/pekko-1.2-nightly-tests.yml
+++ b/.github/workflows/pekko-1.2-nightly-tests.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          ref: 1.1.x
 
       - name: Checkout GitHub merge
         if: github.event.pull_request

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,9 +30,8 @@ jobs:
         include:
           - { javaVersion: '8',  container: "cassandra-latest",  scalaVersion: "++2.13", test: "test" }
           - { javaVersion: '8',  container: "cassandra-latest",  scalaVersion: "++3.3", test: "test" }
-          - { javaVersion: '11', container: "cassandra-latest",  scalaVersion: "++2.12", test: "test" }
           - { javaVersion: '11', container: "cassandra-latest",  scalaVersion: "++2.13", test: "test" }
-          - { javaVersion: '8',  container: "cassandra-latest",  scalaVersion: "++3.3", test: "test" }
+          - { javaVersion: '11', container: "cassandra-latest",  scalaVersion: "++3.3", test: "test" }
           - { javaVersion: '11', container: "cassandra2",        scalaVersion: "++2.13", test: "'testOnly -- -l RequiresCassandraThree'"}
           - { javaVersion: '11', container: "cassandra3",        scalaVersion: "++2.13", test: "test" }
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -294,7 +294,7 @@ pekko.persistence.cassandra {
       class = "SizeTieredCompactionStrategy"
       # If setting a time-to-live then consider using TimeWindowCompactionStratery
       # See [here](http://thelastpickle.com/blog/2016/12/08/TWCS-part1.html) for guideance.
-      # It is reccommended not to have more than 50 buckets so this needs to be based on your
+      # It is recommended not to have more than 50 buckets so this needs to be based on your
       # time-to-live e.g. if you set the TTL to 50 hours and the compaction window to 1 hour
       # there will be 50 buckets.
       # class = "TimeWindowCompactionStrategy"

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/Extractors.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/Extractors.scala
@@ -17,6 +17,7 @@ import java.{ util => ju }
 import java.nio.ByteBuffer
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
 
 import org.apache.pekko
 import pekko.actor.ActorSystem
@@ -27,7 +28,6 @@ import pekko.persistence.cassandra.journal.CassandraJournal._
 import pekko.persistence.query.TimeBasedUUID
 import pekko.serialization.Serialization
 import pekko.util.OptionVal
-import pekko.util.ccompat.JavaConverters._
 
 import com.datastax.oss.driver.api.core.cql.Row
 import com.datastax.oss.protocol.internal.util.Bytes

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/KeyspaceAndTableStatements.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/KeyspaceAndTableStatements.scala
@@ -58,7 +58,7 @@ class KeyspaceAndTableStatements(
    * Cassandra plugin actor.
    */
   def getCreateJournalTablesStatements: java.util.List[String] = {
-    import pekko.util.ccompat.JavaConverters._
+    import scala.jdk.CollectionConverters._
     createJournalTablesStatements.asJava
   }
 
@@ -87,7 +87,7 @@ class KeyspaceAndTableStatements(
    * Cassandra plugin actor.
    */
   def getCreateSnapshotTablesStatements: java.util.List[String] = {
-    import pekko.util.ccompat.JavaConverters._
+    import scala.jdk.CollectionConverters._
     createSnapshotTablesStatements.asJava
   }
 

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/compaction/BaseCompactionStrategy.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/compaction/BaseCompactionStrategy.scala
@@ -15,8 +15,7 @@ package org.apache.pekko.persistence.cassandra.compaction
 
 import com.typesafe.config.{ Config, ConfigFactory }
 
-import org.apache.pekko
-import pekko.util.ccompat.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /*
  * Based upon https://github.com/apache/cassandra/blob/cassandra-2.2/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraEventUpdate.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraEventUpdate.scala
@@ -21,10 +21,10 @@ import pekko.persistence.cassandra.PluginSettings
 import pekko.persistence.cassandra.journal.CassandraJournal.{ Serialized, TagPidSequenceNr }
 import pekko.persistence.cassandra.util.RetryableFutureEval
 import pekko.stream.connectors.cassandra.scaladsl.CassandraSession
-import pekko.util.ccompat.JavaConverters._
 import com.datastax.oss.driver.api.core.cql.{ PreparedStatement, Row, Statement }
 
 import scala.concurrent.{ ExecutionContext, Future }
+import scala.jdk.CollectionConverters._
 import java.lang.{ Long => JLong }
 
 /** INTERNAL API */

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournalStatements.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournalStatements.scala
@@ -20,9 +20,9 @@ import pekko.Done
 import pekko.annotation.InternalApi
 import pekko.event.LoggingAdapter
 import pekko.persistence.cassandra.{ indent, FutureDone, PluginSettings }
-import pekko.util.FutureConverters._
 
 import scala.concurrent.{ ExecutionContext, Future }
+import scala.jdk.FutureConverters._
 
 /**
  * INTERNAL API

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/TagWriters.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/TagWriters.scala
@@ -32,7 +32,6 @@ import pekko.actor.Props
 import pekko.actor.SupervisorStrategy
 import pekko.actor.Timers
 import pekko.annotation.InternalApi
-import pekko.dispatch.ExecutionContexts
 import pekko.event.LoggingAdapter
 import pekko.persistence.cassandra.journal.CassandraJournal._
 import pekko.persistence.cassandra.journal.TagWriter._
@@ -230,7 +229,7 @@ import scala.util.Try
     case BulkTagWrite(tws, withoutTags) =>
       val replyTo = sender()
       val forwards = tws.map(forwardTagWrite)
-      Future.sequence(forwards).map(_ => Done)(ExecutionContexts.parasitic).pipeTo(replyTo)
+      Future.sequence(forwards).map(_ => Done)(ExecutionContext.parasitic).pipeTo(replyTo)
       updatePendingScanning(withoutTags)
     case WriteTagScanningTick =>
       writeTagScanning()
@@ -359,7 +358,7 @@ import scala.util.Try
       Future.successful(Done)
     } else {
       updatePendingScanning(tw.serialised)
-      askTagActor(tw.tag, tw).map(_ => Done)(ExecutionContexts.parasitic)
+      askTagActor(tw.tag, tw).map(_ => Done)(ExecutionContext.parasitic)
     }
   }
 

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/package.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/package.scala
@@ -25,9 +25,9 @@ import pekko.annotation.InternalApi
 import pekko.persistence.cassandra.journal.TimeBucket
 import pekko.persistence.cassandra.journal.CassandraJournal.{ Serialized, SerializedMeta }
 import pekko.serialization.{ AsyncSerializer, Serialization, Serializers }
-import pekko.util.ccompat.JavaConverters._
 
 import scala.concurrent._
+import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 import com.typesafe.config.{ Config, ConfigValueType }
 import com.datastax.oss.driver.api.core.uuid.Uuids

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/EventsByPersistenceIdStage.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/EventsByPersistenceIdStage.scala
@@ -21,13 +21,13 @@ import pekko.annotation.InternalApi
 import pekko.persistence.cassandra.PluginSettings
 import pekko.stream.stage._
 import pekko.stream.{ Attributes, Outlet, SourceShape }
-import pekko.util.FutureConverters._
 
 import java.lang.{ Long => JLong }
 import java.util.concurrent.ThreadLocalRandom
 import scala.annotation.{ nowarn, tailrec }
 import scala.concurrent.duration.{ FiniteDuration, _ }
 import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.jdk.FutureConverters._
 import scala.util.{ Failure, Success, Try }
 
 /**

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/EventsByTagStage.scala
@@ -27,7 +27,6 @@ import pekko.persistence.cassandra.journal.TimeBucket
 import pekko.persistence.cassandra.query.scaladsl.CassandraReadJournal.EventByTagStatements
 import pekko.stream.stage._
 import pekko.stream.{ Attributes, Outlet, SourceShape }
-import pekko.util.FutureConverters._
 import pekko.util.PrettyDuration._
 import pekko.util.UUIDComparator
 
@@ -37,6 +36,7 @@ import java.util.concurrent.ThreadLocalRandom
 import scala.annotation.tailrec
 import scala.concurrent.duration.{ Duration, _ }
 import scala.concurrent.{ ExecutionContext, Future }
+import scala.jdk.FutureConverters._
 import scala.util.{ Failure, Success, Try }
 
 /**

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
@@ -24,7 +24,8 @@ import pekko.persistence.query.TimeBasedUUID
 import pekko.persistence.query.javadsl._
 import pekko.stream.connectors.cassandra.javadsl.CassandraSession
 import pekko.stream.javadsl.Source
-import pekko.util.FutureConverters._
+
+import scala.jdk.FutureConverters._
 
 object CassandraReadJournal {
 

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/snapshot/CassandraSnapshotStatements.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/snapshot/CassandraSnapshotStatements.scala
@@ -15,15 +15,15 @@ package org.apache.pekko.persistence.cassandra.snapshot
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.jdk.FutureConverters._
 
 import org.apache.pekko
-import pekko.util.FutureConverters._
 import pekko.Done
 import pekko.annotation.InternalApi
 import pekko.event.LoggingAdapter
 import pekko.persistence.cassandra.indent
-import com.datastax.oss.driver.api.core.CqlSession
 import pekko.persistence.cassandra.FutureDone
+import com.datastax.oss.driver.api.core.CqlSession
 
 /**
  * INTERNAL API

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -20,7 +20,6 @@ import org.apache.pekko
 import pekko.{ Done, NotUsed }
 import pekko.actor._
 import pekko.annotation.InternalApi
-import pekko.dispatch.ExecutionContexts
 import pekko.event.Logging
 import pekko.pattern.pipe
 import pekko.persistence._
@@ -31,12 +30,12 @@ import pekko.serialization.{ AsyncSerializer, Serialization, SerializationExtens
 import pekko.stream.connectors.cassandra.scaladsl.{ CassandraSession, CassandraSessionRegistry }
 import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.util.{ unused, OptionVal }
-import pekko.util.FutureConverters._
 
 import java.lang.{ Long => JLong }
 import java.nio.ByteBuffer
 import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
+import scala.jdk.FutureConverters._
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success }
 
@@ -400,7 +399,7 @@ import scala.util.{ Failure, Success }
               // Serialization.deserialize adds transport info
               serialization.deserialize(bytes, serId, manifest).get
             }
-        }).map(payload => DeserializedSnapshot(payload, meta))(ExecutionContexts.parasitic)
+        }).map(payload => DeserializedSnapshot(payload, meta))(ExecutionContext.parasitic)
 
       } catch {
         case NonFatal(e) => Future.failed(e)

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraSpec.scala
@@ -179,7 +179,7 @@ abstract class CassandraSpec(
     try {
       if (failed && dumpRowsOnFailure) {
         println("RowDump::")
-        import pekko.util.ccompat.JavaConverters._
+        import scala.jdk.CollectionConverters._
         if (system.settings.config.getBoolean("pekko.persistence.cassandra.events-by-tag.enabled")) {
           println("tag_views")
           cluster

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/cleanup/CleanupSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/cleanup/CleanupSpec.scala
@@ -566,7 +566,7 @@ class CleanupSpec extends CassandraSpec(CleanupSpec.config) with DirectWriting {
   }
 
   private def allSnapshots(pid: String): Seq[SnapshotMetadata] = {
-    import pekko.util.ccompat.JavaConverters._
+    import scala.jdk.CollectionConverters._
     cluster
       .execute(s"select * from ${snapshotName}.snapshots where persistence_id = '${pid}' order by sequence_nr")
       .asScala

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/TagScanningSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/TagScanningSpec.scala
@@ -37,7 +37,7 @@ class TagScanningSpec extends CassandraSpec(TagScanningSpec.config) {
       }
 
       awaitAssert {
-        import pekko.util.ccompat.JavaConverters._
+        import scala.jdk.CollectionConverters._
         val expected = (0 until nrActors).map(n => (s"$n".toInt, 1L)).toList
         val scanning = cluster
           .execute(s"select * from $journalName.tag_scanning")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,10 +11,9 @@ import sbt._
 
 object Dependencies {
   // keep in sync with .github/workflows/unit-tests.yml
-  val scala212Version = "2.12.20"
   val scala213Version = "2.13.16"
   val scala3Version = "3.3.6"
-  val scalaVersions = Seq(scala212Version, scala213Version, scala3Version)
+  val scalaVersions = Seq(scala213Version, scala3Version)
 
   val pekkoVersion = PekkoCoreDependency.version
   val pekkoVersionInDocs = PekkoCoreDependency.default.link


### PR DESCRIPTION
* also switch to using Scala converters and ExecutuinContext.parasistic
* switch the nightly tests to test 1.1.x (temporarily) because we are making breaking changes in 2.0.0