### PR TITLE
use Scala LazyList

### DIFF
--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/TagWriterSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/TagWriterSpec.scala
@@ -33,7 +33,6 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import scala.collection.compat.immutable.LazyList
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.control.NoStackTrace

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,6 @@ object Dependencies {
     "org.apache.cassandra" % "java-driver-core" % driverVersion,
     "io.netty" % "netty-handler" % nettyVersion,
     logback % Test,
-    "org.scala-lang.modules" %% "scala-collection-compat" % "2.13.0" % Test,
     "org.scalatest" %% "scalatest" % "3.2.19" % Test,
     "org.pegdown" % "pegdown" % "1.6.0" % Test,
     "org.osgi" % "org.osgi.core" % "6.0.0" % Provided)


### PR DESCRIPTION
now that we don't support Scala 2.12, we can use Scala's built-in LazyList