### PR TITLE
Update Cassandra bundle version to 3.11.19

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ lazy val cassandraBundle = project
     name := "pekko-persistence-cassandra-bundle",
     crossPaths := false,
     autoScalaLibrary := false,
-    libraryDependencies += ("org.apache.cassandra" % "cassandra-all" % "3.11.3")
+    libraryDependencies += ("org.apache.cassandra" % "cassandra-all" % "3.11.19")
       .exclude("commons-logging", "commons-logging"),
     dependencyOverrides += "com.github.jbellis" % "jamm" % "0.3.3", // See jamm comment in https://issues.apache.org/jira/browse/CASSANDRA-9608
     assembly / assemblyJarName := "cassandra-bundle.jar",

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ lazy val cassandraBundle = project
     assembly / assemblyJarName := "cassandra-bundle.jar",
     assembly / assemblyMergeStrategy := {
       case PathList("META-INF", "versions", _, "module-info.class") => MergeStrategy.discard
-      case _                                                        => MergeStrategy.deduplicate
+      case _                                                        => MergeStrategy.concat
     },
     Compile / packageBin := Def.taskDyn {
       val store = streams.value.cacheStoreFactory.make("shaded-output")

--- a/build.sbt
+++ b/build.sbt
@@ -77,6 +77,10 @@ lazy val cassandraBundle = project
       .exclude("commons-logging", "commons-logging"),
     dependencyOverrides += "com.github.jbellis" % "jamm" % "0.3.3", // See jamm comment in https://issues.apache.org/jira/browse/CASSANDRA-9608
     assembly / assemblyJarName := "cassandra-bundle.jar",
+    assembly / assemblyMergeStrategy := {
+      case PathList("META-INF", "versions", _, "module-info.class") => MergeStrategy.discard
+      case _                                                        => MergeStrategy.deduplicate
+    },
     Compile / packageBin := Def.taskDyn {
       val store = streams.value.cacheStoreFactory.make("shaded-output")
       val uberJarLocation = (assembly / assemblyOutputPath).value


### PR DESCRIPTION
3.11.3 is from 2018 and has CVEs
https://mvnrepository.com/artifact/org.apache.cassandra/cassandra-all?p=4

There is Cassandra 4 and 5 but I think upgrading to latest v3 is a start.