### PR TITLE
Update .scala-steward.conf to remove dependency pins

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,11 +1,4 @@
 updates.pin = [
-  # Pin sbt-paradox to v0.9.x because 0.10.x needs JDK 11
-  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox-project-info", version = "0.9." }
-  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox", version = "0.9." }
-  # Pin sbt-java-formatter to v0.9.x because 0.10.x needs JDK 11
-  { groupId = "com.github.sbt", artifactId = "sbt-java-formatter", version = "0.9." }
-  # Pin logback to v1.3.x because v1.4.x needs JDK11
-  { groupId = "ch.qos.logback", version="1.3." }
   # Scala 3.3 is a LTS
   { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
 ]


### PR DESCRIPTION
Removed pinning for several dependencies that require JDK 11.