### PR TITLE
Add -Yfuture-lazy-vals for Scala 3.3.x builds

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -44,6 +44,10 @@ object Common extends AutoPlugin {
     crossScalaVersions := Dependencies.scalaVersions,
     scalaVersion := Dependencies.scala213Version,
     scalacOptions ++= Seq("-encoding", "UTF-8", "-feature", "-unchecked", "-Xlint", "-Ywarn-dead-code", "-deprecation"),
+    scalacOptions ++= {
+      if (scalaBinaryVersion.value == "3") Seq("-Yfuture-lazy-vals")
+      else Seq.empty
+    },
     Compile / console / scalacOptions --= Seq("-deprecation", "-Xfatal-warnings", "-Xlint", "-Ywarn-unused:imports"),
     Compile / doc / scalacOptions := scalacOptions.value ++ Seq(
       "-doc-title",

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -45,7 +45,7 @@ object Common extends AutoPlugin {
     scalaVersion := Dependencies.scala213Version,
     scalacOptions ++= Seq("-encoding", "UTF-8", "-feature", "-unchecked", "-Xlint", "-Ywarn-dead-code", "-deprecation"),
     scalacOptions ++= {
-      if (scalaBinaryVersion.value == "3") Seq("-Yfuture-lazy-vals")
+      if (scalaBinaryVersion.value == "3") Seq("-Yfuture-lazy-vals", "-release:17")
       else Seq.empty
     },
     Compile / console / scalacOptions --= Seq("-deprecation", "-Xfatal-warnings", "-Xlint", "-Ywarn-unused:imports"),


### PR DESCRIPTION
### Motivation

The Scala 3.3.8 compiler introduced the `-Yfuture-lazy-vals` flag ([scala/scala3-lts#637](https://github.com/scala/scala3-lts/pull/637)) to optionally use `VarHandle` instead of `sun.misc.Unsafe` for lazy val implementation. This prepares libraries for upcoming JDK releases that restrict `sun.misc.Unsafe` access.

### Modification

Add `-Yfuture-lazy-vals` to scalacOptions, conditionally applied only for Scala 3.3.x.

### Result

Scala 3.3.x build uses the future-proof `VarHandle`-based lazy val implementation, compatible with all JDK 9+ versions including future releases that restrict `sun.misc.Unsafe`.

### References

Refs scala/scala3-lts#637
Refs apache/pekko#3059