### PR TITLE
chore: Rewrite to scala3 syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 version                                  = 3.11.1
-runner.dialect                           = scala213
+runner.dialect                           = scala213source3
 project.git                              = true
 style                                    = defaultWithAlign
 docstrings.style                         = Asterisk
@@ -72,3 +72,13 @@ rewriteTokens          = {
   "←": "<-"
 }
 project.layout         = StandardConvention
+
+rewrite.scala3.convertToNewSyntax = true
+runner {
+  dialectOverride {
+    allowSignificantIndentation = false
+    allowAsForImportRename = false
+    allowStarWildcardImport = false
+    allowPostfixStarVarargSplices = false
+  }
+}

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraEventUpdate.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraEventUpdate.scala
@@ -128,7 +128,7 @@ import java.lang.{ Long => JLong }
       session.executeWrite(bound)
     }
 
-  private def prepareUpdate(ps: PreparedStatement, s: Serialized, partitionNr: Long): Statement[_] = {
+  private def prepareUpdate(ps: PreparedStatement, s: Serialized, partitionNr: Long): Statement[?] = {
     // primary key
     ps.bind()
       .setString("persistence_id", s.persistenceId)

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/EventsByPersistenceIdStage.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/EventsByPersistenceIdStage.scala
@@ -86,7 +86,7 @@ import scala.util.{ Failure, Success, Try }
       executeStatement(selectDeletedToQuery.bind(persistenceId).setExecutionProfileName(profile)).map(r =>
         Option(r.one()).map(_.getLong("deleted_to")).getOrElse(0))
 
-    private def executeStatement(statement: Statement[_]): Future[AsyncResultSet] =
+    private def executeStatement(statement: Statement[?]): Future[AsyncResultSet] =
       session.executeAsync(statement).asScala
 
   }
@@ -129,7 +129,7 @@ import scala.util.{ Failure, Success, Try }
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Control) = {
     val logic = new TimerGraphStageLogic(shape) with OutHandler with StageLogging with Control {
 
-      override protected def logSource: Class[_] =
+      override protected def logSource: Class[?] =
         classOf[EventsByPersistenceIdStage]
 
       implicit def ec: ExecutionContext = materializer.executionContext

--- a/core/src/multi-jvm/scala/org/apache/pekko/cluster/persistence/cassandra/EventsByTagMultiJvmSpec.scala
+++ b/core/src/multi-jvm/scala/org/apache/pekko/cluster/persistence/cassandra/EventsByTagMultiJvmSpec.scala
@@ -82,7 +82,7 @@ abstract class EventsByTagMultiJvmSpec
 
   override def initialParticipants: Int = roles.size
 
-  @volatile private var cassandraContainer: CassandraContainer[_] = _
+  @volatile private var cassandraContainer: CassandraContainer[?] = _
 
   "EventsByTag" must {
 

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraSpec.scala
@@ -42,7 +42,7 @@ import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
 object CassandraSpec {
-  def getCallerName(clazz: Class[_]): String = {
+  def getCallerName(clazz: Class[?]): String = {
     val s = Thread.currentThread.getStackTrace
       .map(_.getClassName)
       .dropWhile(

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/CassandraIntegrationSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/CassandraIntegrationSpec.scala
@@ -47,7 +47,7 @@ object CassandraIntegrationSpec {
     def receiveCommand: Receive = {
       case DeleteTo(sequenceNr) =>
         deleteMessages(sequenceNr)
-      case payload: List[_] =>
+      case payload: List[?] =>
         persistAll(payload)(handle)
     }
 

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/CassandraSerializationSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/CassandraSerializationSpec.scala
@@ -49,7 +49,7 @@ class BrokenDeSerialization(override val system: ExtendedActorSystem) extends Ba
   override def toBinary(o: AnyRef): Array[Byte] =
     // I was serious with the class name
     Array.emptyByteArray
-  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef =
+  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef =
     throw new RuntimeException("I can't deserialize a single thing")
 }
 

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/PersistAllSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/PersistAllSpec.scala
@@ -40,7 +40,7 @@ object PersistAllSpec {
     def receiveCommand: Receive = {
       case DeleteTo(sequenceNr) =>
         deleteMessages(sequenceNr)
-      case payload: List[_] =>
+      case payload: List[?] =>
         persistAll(payload)(handle)
     }
 

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/TagWriterSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/TagWriterSpec.scala
@@ -75,7 +75,7 @@ class TagWriterSpec
     shutdown()
 
   val fakePs: Future[PreparedStatement] = Future.successful(null)
-  val successfulWrite: Statement[_] => Future[Done] = _ => Future.successful(Done)
+  val successfulWrite: Statement[?] => Future[Done] = _ => Future.successful(Done)
   val defaultSettings = TagWriterSettings(
     maxBatchSize = 10,
     flushInterval = 10.seconds,

--- a/example/src/main/scala/org/apache/pekko/persistence/cassandra/example/ConfigurablePersistentActor.scala
+++ b/example/src/main/scala/org/apache/pekko/persistence/cassandra/example/ConfigurablePersistentActor.scala
@@ -23,7 +23,7 @@ object ConfigurablePersistentActor {
 
   val Key: EntityTypeKey[Event] = EntityTypeKey[Event]("configurable")
 
-  def init(settings: Settings, system: ActorSystem[_]): ActorRef[ShardingEnvelope[Event]] = {
+  def init(settings: Settings, system: ActorSystem[?]): ActorRef[ShardingEnvelope[Event]] = {
     ClusterSharding(system).init(Entity(Key)(ctx => apply(settings, ctx.entityId)).withRole("write"))
   }
 

--- a/example/src/main/scala/org/apache/pekko/persistence/cassandra/example/EventProcessorStream.scala
+++ b/example/src/main/scala/org/apache/pekko/persistence/cassandra/example/EventProcessorStream.scala
@@ -28,13 +28,13 @@ import scala.concurrent.duration._
 import scala.reflect.ClassTag
 
 class EventProcessorStream[Event: ClassTag](
-    system: ActorSystem[_],
+    system: ActorSystem[?],
     executionContext: ExecutionContext,
     eventProcessorId: String,
     tag: String) {
 
   protected val log: Logger = LoggerFactory.getLogger(getClass)
-  private implicit val sys: ActorSystem[_] = system
+  private implicit val sys: ActorSystem[?] = system
   private implicit val ec: ExecutionContext = executionContext
 
   private val session = CassandraSessionRegistry(system).sessionFor("pekko.persistence.cassandra")

--- a/example/src/main/scala/org/apache/pekko/persistence/cassandra/example/ReadSide.scala
+++ b/example/src/main/scala/org/apache/pekko/persistence/cassandra/example/ReadSide.scala
@@ -36,7 +36,7 @@ object ReadSide {
   }
 
   def apply(
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       topic: ActorRef[Topic.Command[ReadSideTopic.ReadSideMetrics]],
       settings: Settings): Unit = {
     system.log.info("Running {} processors", settings.nrProcessors)

--- a/example/src/main/scala/org/apache/pekko/persistence/cassandra/example/ReadSideTopic.scala
+++ b/example/src/main/scala/org/apache/pekko/persistence/cassandra/example/ReadSideTopic.scala
@@ -18,7 +18,7 @@ object ReadSideTopic {
 
   final case class ReadSideMetrics(count: Long, maxValue: Long, p99: Long, p50: Long)
 
-  def init(context: ActorContext[_]): ActorRef[Topic.Command[ReadSideMetrics]] = {
+  def init(context: ActorContext[?]): ActorRef[Topic.Command[ReadSideMetrics]] = {
     context.spawn(Topic[ReadSideMetrics]("read-side-metrics"), "read-side-metrics")
   }
 

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -22,7 +22,7 @@ trait CopyrightHeader extends AutoPlugin {
 
   override def trigger: PluginTrigger = allRequirements
 
-  protected def headerMappingSettings: Seq[Def.Setting[_]] =
+  protected def headerMappingSettings: Seq[Def.Setting[?]] =
     Seq(Compile, Test).flatMap { config =>
       inConfig(config)(
         Seq(
@@ -34,9 +34,9 @@ trait CopyrightHeader extends AutoPlugin {
             HeaderFileType("template") -> cStyleComment)))
     }
 
-  override def projectSettings: Seq[Def.Setting[_]] = Def.settings(headerMappingSettings, additional)
+  override def projectSettings: Seq[Def.Setting[?]] = Def.settings(headerMappingSettings, additional)
 
-  def additional: Seq[Def.Setting[_]] =
+  def additional: Seq[Def.Setting[?]] =
     Def.settings(Compile / compile := {
         (Compile / headerCreate).value
         (Compile / compile).value


### PR DESCRIPTION
### Motivation
Let Scala 3 Community build compile pekko-persistence-cassandra.

### Modification
Update `.scalafmt.conf` dialect to `scala213source3` and enable Scala 3 syntax rewrite rules (`rewrite.scala3.convertToNewSyntax`), then reformat all sources. Key changes:
- Wildcard type `_` → `?` (e.g. `Class[_]` → `Class[?]`)

### Result
Code is compatible with Scala 3 compiler when built with the community build.

### Tests
Not run - formatting only

### References
Refs apache/pekko#3048