### PR TITLE
chore: unify formatter config - standardize aliases, add JDK17 setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,9 @@ ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 ThisBuild / javafmtFormatterCompatibleJavaVersion := 17
 ThisBuild / evictionErrorLevel := Level.Info
 
+addCommandAlias("checkCodeStyle", "scalafmtCheckAll; scalafmtSbtCheck; javafmtCheckAll; +headerCheckAll")
+addCommandAlias("applyCodeStyle", "+headerCreateAll; scalafmtAll; scalafmtSbt; javafmtAll")
+
 lazy val root = project
   .in(file("."))
   .enablePlugins(Common, ScalaUnidocPlugin)


### PR DESCRIPTION
### Motivation
Align formatter plugins, command aliases, and JDK settings with other pekko sub-projects to reduce maintenance burden and ensure consistent formatting configuration across the ecosystem.

### Modification
- Standardize `checkCodeStyle`/`applyCodeStyle` command aliases
- Add `ThisBuild / javafmtFormatterCompatibleJavaVersion := 17` where missing
- Replace custom `verifyCodeFmt` tasks with standard aliases where applicable
- Upgrade sbt-java-formatter plugin where needed

### Result
Consistent formatter configuration across all pekko sub-projects, enabling unified `sbt checkCodeStyle` / `sbt applyCodeStyle` workflow.

### Tests
Not run - build config change only

### References
None - formatter unification across pekko sub-projects