### PR TITLE
Improve Scala 3.8 forward compatibility

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/EventsByTagStage.scala
@@ -239,7 +239,7 @@ import scala.util.{ Failure, Success, Try }
     new TimerGraphStageLogic(shape) with StageLogging with OutHandler {
       override protected def logSource = classOf[EventsByTagStage]
 
-      var stageState: StageState = _
+      var stageState: StageState = null
       val toOffsetMillis =
         toOffset.map(Uuids.unixTimestamp).getOrElse(Long.MaxValue)
 

--- a/core/src/multi-jvm/scala/org/apache/pekko/cluster/persistence/cassandra/EventsByTagMultiJvmSpec.scala
+++ b/core/src/multi-jvm/scala/org/apache/pekko/cluster/persistence/cassandra/EventsByTagMultiJvmSpec.scala
@@ -82,7 +82,7 @@ abstract class EventsByTagMultiJvmSpec
 
   override def initialParticipants: Int = roles.size
 
-  @volatile private var cassandraContainer: CassandraContainer[?] = _
+  @volatile private var cassandraContainer: CassandraContainer[?] = null
 
   "EventsByTag" must {
 

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/CassandraIntegrationSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/CassandraIntegrationSpec.scala
@@ -78,7 +78,7 @@ object CassandraIntegrationSpec {
   }
 
   class ProcessorC(val persistenceId: String, probe: ActorRef) extends PersistentActor {
-    var last: String = _
+    var last: String = null
 
     def receiveRecover: Receive = {
       case SnapshotOffer(_, snapshot: String) =>

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/query/TestActor.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/query/TestActor.scala
@@ -31,7 +31,7 @@ object TestActor {
 
 class TestActor(override val persistenceId: String, override val journalPluginId: String) extends PersistentActor {
 
-  var lastDelete: ActorRef = _
+  var lastDelete: ActorRef = null
 
   val receiveRecover: Receive = {
     case evt: String =>

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -43,10 +43,22 @@ object Common extends AutoPlugin {
     crossVersion := CrossVersion.binary,
     crossScalaVersions := Dependencies.scalaVersions,
     scalaVersion := Dependencies.scala213Version,
-    scalacOptions ++= Seq("-encoding", "UTF-8", "-feature", "-unchecked", "-Xlint", "-Ywarn-dead-code", "-deprecation"),
+    scalacOptions ++= Seq("-encoding", "UTF-8", "-feature", "-unchecked", "-deprecation"),
     scalacOptions ++= {
-      if (scalaBinaryVersion.value == "3") Seq("-Yfuture-lazy-vals", "-release:17")
-      else Seq.empty
+      if (scalaBinaryVersion.value == "3")
+        Seq(
+          "-Yfuture-lazy-vals",
+          "-release:17",
+          "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
+          "-Wconf:msg=is deprecated for wildcard arguments of types:s",
+          "-Wconf:msg=The trailing ` _` for eta-expansion is unnecessary:s",
+          "-Wconf:msg=with as a type operator has been deprecated:s",
+          "-Wconf:msg=Unreachable case except for null:s",
+          "-Wconf:msg=is no longer supported for vararg splices:s",
+          "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s",
+          "-Wconf:msg=bad option.*-Xlint:s",
+          "-Wconf:msg=bad option.*-Ywarn-dead-code:s")
+      else Seq("-Xlint", "-Ywarn-dead-code")
     },
     Compile / console / scalacOptions --= Seq("-deprecation", "-Xfatal-warnings", "-Xlint", "-Ywarn-unused:imports"),
     Compile / doc / scalacOptions := scalacOptions.value ++ Seq(


### PR DESCRIPTION
## Summary
- Replace `= _` with `= null` in 4 locations (deprecated in Scala 3.8)
- Move Scala 2-only compiler options (`-Xlint`, `-Ywarn-dead-code`) to Scala 2 block
- Add `-Wconf` suppressions for warnings requiring Scala 3-only syntax fixes
- Zero new warnings when compiled with Scala 3.8.4, while maintaining full cross-compilation with Scala 2.13 and 3.3.x

## Test plan
- [x] Verified clean compilation with Scala 3.8.4 (zero new warnings)
- [ ] CI passes on Scala 2.13 and 3.3.x