### PR TITLE
fix: resolve compiler warnings in Cassandra journal and snapshot store

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ val mimaCompareVersion = "1.0.0"
 ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 ThisBuild / javafmtFormatterCompatibleJavaVersion := 17
 ThisBuild / evictionErrorLevel := Level.Info
+Global / excludeLintKeys += previewPath
 
 addCommandAlias("checkCodeStyle", "scalafmtCheckAll; scalafmtSbtCheck; javafmtCheckAll; +headerCheckAll")
 addCommandAlias("applyCodeStyle", "+headerCreateAll; scalafmtAll; scalafmtSbt; javafmtAll")

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournal.scala
@@ -895,10 +895,10 @@ import scala.util.{ Failure, Success, Try }
                   case Failure(ex) =>
                     log.warning(
                       "Deserialization of event metadata failed (pid: [{}], seq_nr: [{}], meta_ser_id: [{}], meta_ser_manifest: [{}], ignoring metadata content. Exception: {}",
-                      Array(
+                      Array[AnyRef](
                         row.getString("persistence_id"),
-                        row.getLong("sequence_nr"),
-                        metaSerId,
+                        Long.box(row.getLong("sequence_nr")),
+                        Int.box(metaSerId),
                         metaSerManifest,
                         ex.toString))
                     OptionVal.None

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -16,6 +16,7 @@ package org.apache.pekko.persistence.cassandra.snapshot
 import com.datastax.oss.driver.api.core.cql._
 import com.datastax.oss.protocol.internal.util.Bytes
 import com.typesafe.config.Config
+import scala.annotation.nowarn
 import org.apache.pekko
 import pekko.{ Done, NotUsed }
 import pekko.actor._
@@ -120,6 +121,7 @@ import scala.util.{ Failure, Success }
     } yield res
   }
 
+  @nowarn("msg=match may not be exhaustive")
   private def loadNAsync(metadata: immutable.Seq[SnapshotMetadata]): Future[Option[SelectedSnapshot]] = metadata match {
     case Seq()     => Future.successful(None) // no snapshots stored
     case md +: mds =>
@@ -371,10 +373,10 @@ import scala.util.{ Failure, Success }
                   case Failure(ex) =>
                     log.warning(
                       "Deserialization of snapshot metadata failed (pid: [{}], seq_nr: [{}], meta_ser_id: [{}], meta_ser_manifest: [{}], ignoring metadata content. Exception: {}",
-                      Array(
+                      Array[AnyRef](
                         row.getString("persistence_id"),
-                        row.getLong("sequence_nr"),
-                        metaSerId,
+                        Long.box(row.getLong("sequence_nr")),
+                        Int.box(metaSerId),
                         metaSerManifest,
                         ex.toString))
                     OptionVal.None

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -36,7 +36,8 @@ object Common extends AutoPlugin {
         "Contributors",
         "dev@pekko.apache.org",
         url("https://github.com/apache/pekko-persistence-cassandra/graphs/contributors")),
-      description := "A Cassandra plugin for Apache Pekko Persistence.")
+      description := "A Cassandra plugin for Apache Pekko Persistence.",
+      excludeLintKeys += projectInfoVersion)
 
   override lazy val projectSettings = Seq(
     projectInfoVersion := (if (isSnapshot.value) "snapshot" else version.value),


### PR DESCRIPTION
### Motivation
Compilation produces several warnings that should be resolved:
- "a type was inferred to be `Any`; this may indicate a programming error" in `CassandraJournal.scala:898` and `CassandraSnapshotStore.scala:374`
- "match may not be exhaustive" in `CassandraSnapshotStore.scala:123`
- sbt lint warnings about unused keys `projectInfoVersion` (core, dseTest, endToEndExample, root) and `previewPath` (docs/previewSite)

### Modification
- Add explicit `Array[AnyRef]` type annotation and `Long.box`/`Int.box` for primitive values in `log.warning` `Array` arguments in both `CassandraJournal` and `CassandraSnapshotStore`
- Add `@nowarn("msg=match may not be exhaustive")` on `loadNAsync` where the `Seq()` and `+:` patterns are actually exhaustive for `immutable.Seq` but the compiler does not recognize this
- Add `excludeLintKeys` for `projectInfoVersion` in `Common.scala` and `previewPath` in `build.sbt`

### Result
Clean compilation with no warnings.

### Tests
- `sbt "clean; compile"` passes with no warnings

### References
None - compiler warning cleanup