### PR TITLE
fix: make -Yfuture-lazy-vals conditional for Scala 3.9+

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -57,7 +57,9 @@ object Common extends AutoPlugin {
           "-Wconf:msg=is no longer supported for vararg splices:s",
           "-Wconf:msg=bad option.*-Xlint:s",
           "-Wconf:msg=bad option.*-Ywarn-dead-code:s") ++
-        (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s") else Seq.empty)
+        (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9))
+           Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
+         else Seq.empty)
       else Seq("-Xlint", "-Ywarn-dead-code")
     },
     Compile / console / scalacOptions --= Seq("-deprecation", "-Xfatal-warnings", "-Xlint", "-Ywarn-unused:imports"),

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -48,7 +48,6 @@ object Common extends AutoPlugin {
     scalacOptions ++= {
       if (scalaBinaryVersion.value == "3")
         Seq(
-          "-Yfuture-lazy-vals",
           "-release:17",
           "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
           "-Wconf:msg=is deprecated for wildcard arguments of types:s",
@@ -56,9 +55,9 @@ object Common extends AutoPlugin {
           "-Wconf:msg=with as a type operator has been deprecated:s",
           "-Wconf:msg=Unreachable case except for null:s",
           "-Wconf:msg=is no longer supported for vararg splices:s",
-          "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s",
           "-Wconf:msg=bad option.*-Xlint:s",
-          "-Wconf:msg=bad option.*-Ywarn-dead-code:s")
+          "-Wconf:msg=bad option.*-Ywarn-dead-code:s") ++
+        (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s") else Seq.empty)
       else Seq("-Xlint", "-Ywarn-dead-code")
     },
     Compile / console / scalacOptions --= Seq("-deprecation", "-Xfatal-warnings", "-Xlint", "-Ywarn-unused:imports"),


### PR DESCRIPTION
### Motivation
Scala 3.9 removed the `-Yfuture-lazy-vals` compiler option as the future lazy vals behavior is now the default. Passing this flag on Scala 3.9+ causes a compilation error.

### Modification
Made `-Yfuture-lazy-vals` conditional on Scala minor version < 9 using `CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)`.

### Result
Project compiles on both Scala 3.3.x (which needs the flag) and Scala 3.9+ (which has the behavior by default).

### Tests
- `sbt "++3.9.0-RC1!; compile"` — no -Yfuture-lazy-vals error
- `sbt "++3.3.7!; compile"` — flag still applied

### References
- Part of the Scala 3.9 compatibility effort across all Pekko projects