### PR TITLE
refactor: remove deprecated classic remoting message types from muteDeadLetters

### DIFF
--- a/core/src/multi-jvm/scala/org/apache/pekko/cluster/persistence/cassandra/MultiNodeClusterSpec.scala
+++ b/core/src/multi-jvm/scala/org/apache/pekko/cluster/persistence/cassandra/MultiNodeClusterSpec.scala
@@ -128,12 +128,7 @@ trait MultiNodeClusterSpec extends Suite with STMultiNodeSpec with FlightRecordi
 
       muteDeadLetters(
         classOf[pekko.actor.PoisonPill],
-        classOf[pekko.dispatch.sysmsg.DeathWatchNotification],
-        classOf[pekko.remote.transport.AssociationHandle.Disassociated],
-        //        pekko.remote.transport.AssociationHandle.Disassociated.getClass,
-        classOf[pekko.remote.transport.ActorTransportAdapter.DisassociateUnderlying],
-        //        pekko.remote.transport.ActorTransportAdapter.DisassociateUnderlying.getClass,
-        classOf[pekko.remote.transport.AssociationHandle.InboundPayload])(sys)
+        classOf[pekko.dispatch.sysmsg.DeathWatchNotification])(sys)
 
     }
   }


### PR DESCRIPTION
### Motivation
Classic remoting transport classes (`AssociationHandle.Disassociated`, `ActorTransportAdapter.DisassociateUnderlying`, `AssociationHandle.InboundPayload`) have been deprecated since Akka 2.6.0 in favor of Artery. This project already uses Artery (configured via `pekko.remote.artery.*`).

### Modification
Remove the three deprecated classic remoting message type references from `muteDeadLetters` in `MultiNodeClusterSpec.scala`. Keep the non-deprecated `PoisonPill` and `DeathWatchNotification` references.

### Result
Removes references to deprecated classic remoting API. Artery does not produce these message types, so the suppression was unnecessary.

### Tests
- Not run — multi-jvm test infrastructure only

### References
None — deprecated API cleanup