### PR TITLE
build: enable -Xfatal-warnings for Scala 2 and -Werror for Scala 3

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -44,10 +44,11 @@ object Common extends AutoPlugin {
     crossVersion := CrossVersion.binary,
     crossScalaVersions := Dependencies.scalaVersions,
     scalaVersion := Dependencies.scala213Version,
-    scalacOptions ++= Seq("-encoding", "UTF-8", "-feature", "-unchecked", "-deprecation"),
+    scalacOptions ++= Seq("-encoding", "UTF-8", "-feature", "-unchecked", "-deprecation", "-Xfatal-warnings"),
     scalacOptions ++= {
       if (scalaBinaryVersion.value == "3")
         Seq(
+          "-Werror",
           "-release:17",
           "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
           "-Wconf:msg=is deprecated for wildcard arguments of types:s",
@@ -56,7 +57,8 @@ object Common extends AutoPlugin {
           "-Wconf:msg=Unreachable case except for null:s",
           "-Wconf:msg=is no longer supported for vararg splices:s",
           "-Wconf:msg=bad option.*-Xlint:s",
-          "-Wconf:msg=bad option.*-Ywarn-dead-code:s") ++
+          "-Wconf:msg=bad option.*-Ywarn-dead-code:s",
+          "-Wconf:msg=bad option.*-Xfatal-warnings:s") ++
         (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9))
            Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
          else Seq.empty)


### PR DESCRIPTION
### Motivation
Treating warnings as errors ensures that deprecated API usage and other code quality issues are caught at compile time rather than accumulating silently.

### Modification
- Add `-Xfatal-warnings` to main `scalacOptions` in `Common.scala`
- Add `-Werror` to Scala 3 `scalacOptions`
- Console and doc scopes already exclude `-Xfatal-warnings`

### Result
All compiler warnings are now treated as errors, enforcing higher code quality.

### Tests
- CI will verify compilation

### References
None — build configuration improvement