### PR TITLE
fix: fix scaladoc warnings in query module

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
@@ -118,7 +118,7 @@ class CassandraReadJournal(
    * The tags must be defined in the `tags` section of the `pekko.persistence.cassandra` configuration.
    *
    * You can use [[pekko.persistence.query.NoOffset]] to retrieve all events with a given tag or
-   * retrieve a subset of all events by specifying a [[TimeBasedUUID]] `offset`.
+   * retrieve a subset of all events by specifying a [[org.apache.pekko.persistence.query.TimeBasedUUID TimeBasedUUID]] `offset`.
    *
    * The offset of each event is provided in the streamed envelopes returned,
    * which makes it possible to resume the stream at a later point from a given offset.

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -266,7 +266,7 @@ class CassandraReadJournal protected (
    * in a `org.apache.pekko.persistence.journal.Tagged` with the given `tags`.
    * The tags must be defined in the `tags` section of the `pekko.persistence.cassandra` configuration.
    *
-   * You can use [[NoOffset]] to retrieve all events with a given tag or
+   * You can use [[org.apache.pekko.persistence.query.NoOffset NoOffset]] to retrieve all events with a given tag or
    * retrieve a subset of all events by specifying a `TimeBasedUUID` `offset`.
    *
    * The offset of each event is provided in the streamed envelopes returned,


### PR DESCRIPTION
### Motivation
Running `sbt doc` produces scaladoc warnings about unresolvable links in the query module.

### Modification
- `query/javadsl/CassandraReadJournal.scala`: Use fully qualified `org.apache.pekko.persistence.query.TimeBasedUUID` path for the `TimeBasedUUID` link
- `query/scaladsl/CassandraReadJournal.scala`: Use fully qualified `org.apache.pekko.persistence.query.NoOffset` path for the `NoOffset` link

### Result
Scaladoc warnings are eliminated.

### Tests
Not run - docs only

### References
None