### PR TITLE
fix: fix compilation warnings across all Scala versions

### DIFF
--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraSpec.scala
@@ -40,6 +40,7 @@ import org.scalatest.matchers.should.Matchers
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
+import scala.annotation.nowarn
 
 object CassandraSpec {
   def getCallerName(clazz: Class[?]): String = {
@@ -98,6 +99,7 @@ object CassandraSpec {
 /**
  * Picks a free port for Cassandra before starting the ActorSystem
  */
+@nowarn("msg=getClass not selected from this instance")
 abstract class CassandraSpec(
     config: Config = CassandraLifecycle.config,
     val journalName: String = getCallerName(getClass),

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/CassandraIntegrationSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/CassandraIntegrationSpec.scala
@@ -381,7 +381,7 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
       val r = system.actorOf(Props(new ProcessorA(persistenceId, self)))
 
       r ! "b"
-      expectMsgAllOf("b", 2L, false) // no longer re-using sequence numbers
+      expectMsgAllOf[Any]("b", 2L, false) // no longer re-using sequence numbers
     }
   }
 }

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/ManyActorsLoadSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/ManyActorsLoadSpec.scala
@@ -38,7 +38,6 @@ object ManyActorsLoadSpec {
 
   final case class Init(numberOfEvents: Int)
   case object InitDone
-  private final case class Next(remaining: Int)
   final case class Delete(seqNr: Long)
   case object GetMetrics
   final case class Metrics(

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/query/EventsByTagSpec.scala
@@ -520,7 +520,7 @@ class EventsByTagSpec extends AbstractEventsByTagSpec(EventsByTagSpec.config) {
           probe.request(200)
           for (n <- 1 to 100) {
             val Expected = s"yellow-$n"
-            probe.expectNextPF { case e @ EventEnvelope(_, "e", _, Expected) => e }
+            probe.expectNextPF { case env @ EventEnvelope(_, "e", _, Expected) => env }
           }
           probe.expectNoMessage(waitTime)
 
@@ -530,7 +530,7 @@ class EventsByTagSpec extends AbstractEventsByTagSpec(EventsByTagSpec.config) {
           for (n <- 101 to 200) {
             val Expected = s"yellow-$n"
             withClue(s"Expected: $Expected") {
-              probe.expectNextPF { case e @ EventEnvelope(_, "e", _, Expected) => e }
+              probe.expectNextPF { case env @ EventEnvelope(_, "e", _, Expected) => env }
             }
           }
           probe.expectNoMessage(waitTime)
@@ -1358,7 +1358,6 @@ object EventsByTagDisabledSpec {
 
 class EventsByTagPersistenceIdCleanupSpec extends AbstractEventsByTagSpec(EventsByTagSpec.persistenceIdCleanupConfig) {
 
-  private val newPersistenceIdScan: FiniteDuration = 500.millis
   private val cleanupPeriod: FiniteDuration = 1.second
 
   private val logFilters = Set("cleanup-old-persistence-ids has been set")

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/sharding/ClusterShardingQuickTerminationSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/sharding/ClusterShardingQuickTerminationSpec.scala
@@ -72,6 +72,7 @@ object ClusterShardingQuickTerminationSpec {
   val extractShardId: ShardRegion.ExtractShardId = {
     case EntityEnvelope(id, _) => (id % numberOfShards).toString
     case Get(id)               => (id % numberOfShards).toString
+    case msg                   => throw new IllegalArgumentException(s"Unexpected message: $msg")
   }
 }
 


### PR DESCRIPTION
### Motivation
Compilation produced 8 warnings in Scala 2.13 test sources:
- "getClass not selected from this instance" in CassandraSpec constructor default params (x2)
- "a type was inferred to be `Any`" in CassandraIntegrationSpec
- "private class Next is never used" in ManyActorsLoadSpec
- "private val newPersistenceIdScan is never used" in EventsByTagPersistenceIdCleanupSpec
- "Name e is already introduced in an enclosing scope" (x2) in EventsByTagSpec
- "match may not be exhaustive" in ClusterShardingQuickTerminationSpec

### Modification
- Add `@nowarn` annotation on CassandraSpec for intentional `getClass` usage in constructor default parameters
- Add explicit `[Any]` type parameter to `expectMsgAllOf` call in CassandraIntegrationSpec
- Remove unused private case class `Next` from ManyActorsLoadSpec
- Remove unused private val `newPersistenceIdScan` from EventsByTagPersistenceIdCleanupSpec
- Rename shadowed pattern variable `e` to `env` in EventsByTagSpec (x2)
- Add catch-all case to `extractShardId` partial function for exhaustiveness

### Result
Clean compilation with zero warnings across all Scala versions (2.13 and 3).

### Tests
- `sbt +test:compile` - all versions pass with no warnings

### References
None - code quality improvement