### PR TITLE
Use StandardCharsets.UTF_8 for snapshot test bytes

### DIFF
--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
   <!-- Silence initial setup logging from Logback -->
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
@@ -16,6 +16,7 @@ package org.apache.pekko.persistence.cassandra.snapshot
 import java.lang.{ Long => JLong }
 import java.lang.{ Integer => JInteger }
 import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
 
 import org.apache.pekko
 import pekko.persistence.SnapshotProtocol._
@@ -91,7 +92,7 @@ class CassandraSnapshotStoreSpec
           123L: JLong,
           serId,
           "",
-          ByteBuffer.wrap("fail-1".getBytes("UTF-8"))))
+          ByteBuffer.wrap("fail-1".getBytes(StandardCharsets.UTF_8))))
 
       cluster.execute(
         SimpleStatement.newInstance(
@@ -101,7 +102,7 @@ class CassandraSnapshotStoreSpec
           124L: JLong,
           serId,
           "",
-          ByteBuffer.wrap("fail-2".getBytes("UTF-8"))))
+          ByteBuffer.wrap("fail-2".getBytes(StandardCharsets.UTF_8))))
 
       // load most recent snapshot, first two attempts will fail ...
       snapshotStore.tell(LoadSnapshot(pid, SnapshotSelectionCriteria.Latest, Long.MaxValue), probe.ref)
@@ -127,7 +128,7 @@ class CassandraSnapshotStoreSpec
           123L: JLong,
           serId,
           "",
-          ByteBuffer.wrap("fail-1".getBytes("UTF-8"))))
+          ByteBuffer.wrap("fail-1".getBytes(StandardCharsets.UTF_8))))
       cluster.execute(
         SimpleStatement.newInstance(
           writeSnapshot(withMeta = false),
@@ -136,7 +137,7 @@ class CassandraSnapshotStoreSpec
           124L: JLong,
           serId,
           "",
-          ByteBuffer.wrap("fail-2".getBytes("UTF-8"))))
+          ByteBuffer.wrap("fail-2".getBytes(StandardCharsets.UTF_8))))
       cluster.execute(
         SimpleStatement.newInstance(
           writeSnapshot(withMeta = false),
@@ -145,7 +146,7 @@ class CassandraSnapshotStoreSpec
           125L: JLong,
           serId,
           "",
-          ByteBuffer.wrap("fail-3".getBytes("UTF-8"))))
+          ByteBuffer.wrap("fail-3".getBytes(StandardCharsets.UTF_8))))
 
       // load most recent snapshot, first three attempts will fail ...
       snapshotStore.tell(LoadSnapshot(pid, SnapshotSelectionCriteria.Latest, Long.MaxValue), probe.ref)

--- a/example/src/main/resources/logback.xml
+++ b/example/src/main/resources/logback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
   <appender name="CONSOLE"
   class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
Summary: Replace UTF-8 string arguments with StandardCharsets.UTF_8 in snapshot store tests and normalize lowercase XML encoding declarations. Verification: ran formatting, core Test compile, XML validation, git diff --check, and residual charset literal searches.