### PR TITLE
chore: update scala3Next to 3.9.0-RC3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   // keep in sync with .github/workflows/unit-tests.yml
   val scala213Version = "2.13.18"
   val scala3Version = "3.3.8"
-  val scala3NextVersion = "3.8.4"
+  val scala3NextVersion = "3.9.0-RC1"
   val publishedScalaVersions = Seq(scala213Version, scala3Version)
 
   val pekkoVersion = PekkoCoreDependency.version

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   // keep in sync with .github/workflows/unit-tests.yml
   val scala213Version = "2.13.18"
   val scala3Version = "3.3.8"
-  val scala3NextVersion = "3.9.0-RC1"
+  val scala3NextVersion = "3.9.0-RC3"
   val publishedScalaVersions = Seq(scala213Version, scala3Version)
 
   val pekkoVersion = PekkoCoreDependency.version


### PR DESCRIPTION
### Motivation
Scala 3.9.0-RC3 is available and should be tested as the next Scala version.

### Modification
Update scala3Next version from 3.8.4 to 3.9.0-RC3.

### Result
Build will use Scala 3.9.0-RC3 as the next Scala version.

### Tests
Not run - version bump only

### References
None - version bump