### PR TITLE
Update ScyllaDB image version to 2026.1.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       retries: 60
 
   scylladb-service:
-    image: scylladb/scylla:latest
+    image: scylladb/scylla:2026.1.6
     ports:
       - "9042:9042"
     volumes:


### PR DESCRIPTION
See #468 

Hope is that if we go back to an image released a month ago that we might see a successful CI.

We can later investigate what changed.