### PR TITLE
validate keyspace and tablenames

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/EventsByTagSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/EventsByTagSettings.scala
@@ -23,6 +23,7 @@ import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.annotation.InternalApi
 import pekko.event.Logging
+import pekko.persistence.cassandra.PluginSettings.validateTableName
 import pekko.persistence.cassandra.compaction.CassandraCompactionStrategy
 import pekko.persistence.cassandra.journal.TagWriter.TagWriterSettings
 import pekko.persistence.cassandra.journal.TimeBucket
@@ -137,7 +138,7 @@ import com.typesafe.config.Config
   }
 
   val tagTable = TableSettings(
-    eventsByTagConfig.getString("table"),
+    validateTableName(eventsByTagConfig.getString("table")),
     CassandraCompactionStrategy(eventsByTagConfig.getConfig("compaction-strategy")),
     eventsByTagConfig.getLong("gc-grace-seconds"),
     if (eventsByTagConfig.hasPath("time-to-live"))

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/PluginSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/PluginSettings.scala
@@ -56,7 +56,7 @@ import com.typesafe.config.Config
     new PluginSettings(system, config)
 
   val keyspaceNameRegex =
-    """^("[a-zA-Z]{1}[\w]{0,47}"|[a-zA-Z]{1}[\w]{0,47})$"""
+    """^([a-zA-Z_][a-zA-Z0-9_]{0,47}|"[^"]{1,48}")$"""
 
   /**
    * Builds replication strategy command to create a keyspace.
@@ -107,7 +107,7 @@ import com.typesafe.config.Config
       keyspaceName
     } else {
       throw new IllegalArgumentException(
-        s"Invalid keyspace name. A keyspace may have 32 or fewer alpha-numeric characters and underscores. Value was: $keyspaceName")
+        s"Invalid keyspace name. A keyspace may have 48 or fewer alpha-numeric characters and underscores, or be double-quoted. Value was: $keyspaceName")
     }
 
   /**
@@ -122,6 +122,6 @@ import com.typesafe.config.Config
       tableName
     } else {
       throw new IllegalArgumentException(
-        s"Invalid table name. A table name may have 32 or fewer alpha-numeric characters and underscores. Value was: $tableName")
+        s"Invalid table name. A table name may have 48 or fewer alpha-numeric characters and underscores, or be double-quoted. Value was: $tableName")
     }
 }

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/PluginSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/PluginSettings.scala
@@ -55,8 +55,11 @@ import com.typesafe.config.Config
   def apply(system: ActorSystem, config: Config): PluginSettings =
     new PluginSettings(system, config)
 
+  // An unquoted CQL identifier must start with a letter and may contain letters, digits and
+  // underscores. A quoted identifier is case sensitive and may contain any character except the
+  // double quote itself. Either form is limited to 48 characters.
   val keyspaceNameRegex =
-    """^([a-zA-Z_][a-zA-Z0-9_]{0,47}|"[^"]{1,48}")$"""
+    """^([a-zA-Z][a-zA-Z0-9_]{0,47}|"[^"]{1,48}")$"""
 
   /**
    * Builds replication strategy command to create a keyspace.
@@ -107,7 +110,9 @@ import com.typesafe.config.Config
       keyspaceName
     } else {
       throw new IllegalArgumentException(
-        s"Invalid keyspace name. A keyspace may have 48 or fewer alpha-numeric characters and underscores, or be double-quoted. Value was: $keyspaceName")
+        s"Invalid keyspace name. An unquoted keyspace name must start with a letter and may have 48 or fewer " +
+        s"alpha-numeric characters and underscores. Alternatively it may be a double-quoted identifier of 1 to 48 " +
+        s"characters. Value was: $keyspaceName")
     }
 
   /**
@@ -122,6 +127,8 @@ import com.typesafe.config.Config
       tableName
     } else {
       throw new IllegalArgumentException(
-        s"Invalid table name. A table name may have 48 or fewer alpha-numeric characters and underscores, or be double-quoted. Value was: $tableName")
+        s"Invalid table name. An unquoted table name must start with a letter and may have 48 or fewer " +
+        s"alpha-numeric characters and underscores. Alternatively it may be a double-quoted identifier of 1 to 48 " +
+        s"characters. Value was: $tableName")
     }
 }

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/JournalSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/JournalSettings.scala
@@ -19,6 +19,8 @@ import pekko.actor.NoSerializationVerificationNeeded
 import pekko.annotation.InternalApi
 import pekko.annotation.InternalStableApi
 import pekko.persistence.cassandra.PluginSettings.getReplicationStrategy
+import pekko.persistence.cassandra.PluginSettings.validateKeyspaceName
+import pekko.persistence.cassandra.PluginSettings.validateTableName
 import pekko.persistence.cassandra.compaction.CassandraCompactionStrategy
 import pekko.persistence.cassandra.getListFromConfig
 import com.typesafe.config.Config
@@ -36,11 +38,11 @@ import com.typesafe.config.Config
   val keyspaceAutoCreate: Boolean = journalConfig.getBoolean("keyspace-autocreate")
   val tablesAutoCreate: Boolean = journalConfig.getBoolean("tables-autocreate")
 
-  val keyspace: String = journalConfig.getString("keyspace")
+  val keyspace: String = validateKeyspaceName(journalConfig.getString("keyspace"))
 
-  val table: String = journalConfig.getString("table")
-  val metadataTable: String = journalConfig.getString("metadata-table")
-  val allPersistenceIdsTable: String = journalConfig.getString("all-persistence-ids-table")
+  val table: String = validateTableName(journalConfig.getString("table"))
+  val metadataTable: String = validateTableName(journalConfig.getString("metadata-table"))
+  val allPersistenceIdsTable: String = validateTableName(journalConfig.getString("all-persistence-ids-table"))
 
   val tableCompactionStrategy: CassandraCompactionStrategy =
     CassandraCompactionStrategy(journalConfig.getConfig("table-compaction-strategy"))

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/snapshot/SnapshotSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/snapshot/SnapshotSettings.scala
@@ -17,6 +17,8 @@ import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.annotation.InternalApi
 import pekko.persistence.cassandra.PluginSettings.getReplicationStrategy
+import pekko.persistence.cassandra.PluginSettings.validateKeyspaceName
+import pekko.persistence.cassandra.PluginSettings.validateTableName
 import pekko.persistence.cassandra.compaction.CassandraCompactionStrategy
 import pekko.persistence.cassandra.getListFromConfig
 import com.typesafe.config.Config
@@ -31,9 +33,9 @@ import com.typesafe.config.Config
   val keyspaceAutoCreate: Boolean = snapshotConfig.getBoolean("keyspace-autocreate")
   val tablesAutoCreate: Boolean = snapshotConfig.getBoolean("tables-autocreate")
 
-  val keyspace: String = snapshotConfig.getString("keyspace")
+  val keyspace: String = validateKeyspaceName(snapshotConfig.getString("keyspace"))
 
-  val table: String = snapshotConfig.getString("table")
+  val table: String = validateTableName(snapshotConfig.getString("table"))
 
   val tableCompactionStrategy: CassandraCompactionStrategy =
     CassandraCompactionStrategy(snapshotConfig.getConfig("table-compaction-strategy"))

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraPluginSettingsSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraPluginSettingsSpec.scala
@@ -24,6 +24,8 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 import scala.util.Random
 
 import pekko.persistence.cassandra.journal.JournalSettings
+import pekko.persistence.cassandra.snapshot.SnapshotSettings
+import pekko.persistence.cassandra.EventsByTagSettings
 
 class CassandraPluginSettingsSpec
     extends TestKit(ActorSystem("CassandraPluginConfigSpec"))
@@ -130,6 +132,62 @@ class CassandraPluginSettingsSpec
             PluginSettings.validateKeyspaceName(tableName)
           }
       }
+    }
+
+    "reject invalid keyspace name in JournalSettings" in {
+      val badConfig =
+        ConfigFactory.parseString("""journal.keyspace = "invalid;name"""").withFallback(defaultConfig)
+      intercept[IllegalArgumentException] {
+        new JournalSettings(system, badConfig)
+      }.getMessage must include("Invalid keyspace name")
+    }
+
+    "reject invalid table name in JournalSettings" in {
+      val badConfig =
+        ConfigFactory.parseString("""journal.table = "invalid;table"""").withFallback(defaultConfig)
+      intercept[IllegalArgumentException] {
+        new JournalSettings(system, badConfig)
+      }.getMessage must include("Invalid table name")
+    }
+
+    "reject invalid metadata table name in JournalSettings" in {
+      val badConfig =
+        ConfigFactory.parseString("""journal.metadata-table = "bad-name"""").withFallback(defaultConfig)
+      intercept[IllegalArgumentException] {
+        new JournalSettings(system, badConfig)
+      }.getMessage must include("Invalid table name")
+    }
+
+    "reject invalid all-persistence-ids table name in JournalSettings" in {
+      val badConfig =
+        ConfigFactory.parseString("""journal.all-persistence-ids-table = "bad-name"""").withFallback(defaultConfig)
+      intercept[IllegalArgumentException] {
+        new JournalSettings(system, badConfig)
+      }.getMessage must include("Invalid table name")
+    }
+
+    "reject invalid keyspace name in SnapshotSettings" in {
+      val badConfig =
+        ConfigFactory.parseString("""snapshot.keyspace = "invalid;name"""").withFallback(defaultConfig)
+      intercept[IllegalArgumentException] {
+        new SnapshotSettings(system, badConfig)
+      }.getMessage must include("Invalid keyspace name")
+    }
+
+    "reject invalid table name in SnapshotSettings" in {
+      val badConfig =
+        ConfigFactory.parseString("""snapshot.table = "invalid;table"""").withFallback(defaultConfig)
+      intercept[IllegalArgumentException] {
+        new SnapshotSettings(system, badConfig)
+      }.getMessage must include("Invalid table name")
+    }
+
+    "reject invalid tag table name in EventsByTagSettings" in {
+      val badConfig =
+        ConfigFactory.parseString("""events-by-tag.table = "bad-name"""").withFallback(defaultConfig)
+      intercept[IllegalArgumentException] {
+        new EventsByTagSettings(system, badConfig)
+      }.getMessage must include("Invalid table name")
     }
 
     "parse keyspace-autocreate parameter" in {

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraPluginSettingsSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraPluginSettingsSpec.scala
@@ -40,12 +40,33 @@ class CassandraPluginSettingsSpec
     def maxKey = Random.alphanumeric.dropWhile(_.toString.matches("[^a-zA-Z]")).take(48).mkString
 
     Table(
-      ("Keyspace", "isValid"), ("test", true), ("_test_123", false), ("", false), ("test-space", false),
-      ("'test'", false), ("a", true), ("a_", true), ("1", false), ("a1", true), ("_", false), ("asdf!", false),
-      (maxKey, true), ("\"_asdf\"", false), ("\"_\"", false), ("\"a\"", true), ("\"a_sdf\"", true), ("\"\"", false),
-      ("\"valid_with_quotes\"", true), ("\"missing_trailing_quote", false), ("missing_leading_quote\"", false),
-      ('"'.toString + maxKey + '"'.toString, true), // using interpolation here breaks scalafmt :-/
-      (maxKey + "_", false))
+      ("Keyspace", "isValid"),
+      // unquoted: letter or underscore start, alphanumeric/underscore, max 48
+      ("test", true),
+      ("_test_123", true),
+      ("", false),
+      ("test-space", false),
+      ("'test'", false),
+      ("a", true),
+      ("a_", true),
+      ("1", false),
+      ("a1", true),
+      ("_", true),
+      ("asdf!", false),
+      (maxKey, true),
+      (maxKey + "_", false),
+      // quoted: any content inside double quotes, max 48 chars
+      ("\"_asdf\"", true),
+      ("\"_\"", true),
+      ("\"a\"", true),
+      ("\"a_sdf\"", true),
+      ("\"\"", false),
+      ("\"valid_with_quotes\"", true),
+      ("\"test-space\"", true),
+      ("\"My Table\"", true),
+      ("\"missing_trailing_quote", false),
+      ("missing_leading_quote\"", false),
+      ('"'.toString + maxKey + '"'.toString, true))
   }
 
   override protected def afterAll(): Unit = {

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraPluginSettingsSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraPluginSettingsSpec.scala
@@ -41,9 +41,9 @@ class CassandraPluginSettingsSpec
 
     Table(
       ("Keyspace", "isValid"),
-      // unquoted: letter or underscore start, alphanumeric/underscore, max 48
+      // unquoted: must start with a letter, then alphanumeric/underscore, max 48 chars
       ("test", true),
-      ("_test_123", true),
+      ("_test_123", false),
       ("", false),
       ("test-space", false),
       ("'test'", false),
@@ -51,11 +51,11 @@ class CassandraPluginSettingsSpec
       ("a_", true),
       ("1", false),
       ("a1", true),
-      ("_", true),
+      ("_", false),
       ("asdf!", false),
       (maxKey, true),
       (maxKey + "_", false),
-      // quoted: any content inside double quotes, max 48 chars
+      // quoted: any content except a double quote, 1 to 48 chars
       ("\"_asdf\"", true),
       ("\"_\"", true),
       ("\"a\"", true),
@@ -147,11 +147,11 @@ class CassandraPluginSettingsSpec
 
     "validate table name parameter" in {
       forAll(keyspaceNames) { (tableName, isValid) =>
-        if (isValid) PluginSettings.validateKeyspaceName(tableName) must be(tableName)
+        if (isValid) PluginSettings.validateTableName(tableName) must be(tableName)
         else
           intercept[IllegalArgumentException] {
-            PluginSettings.validateKeyspaceName(tableName)
-          }
+            PluginSettings.validateTableName(tableName)
+          }.getMessage must include("Invalid table name")
       }
     }
 
@@ -209,6 +209,34 @@ class CassandraPluginSettingsSpec
       intercept[IllegalArgumentException] {
         new EventsByTagSettings(system, badConfig)
       }.getMessage must include("Invalid table name")
+    }
+
+    // Quoted identifiers are case sensitive in CQL and may contain characters that are not
+    // allowed unquoted, so they must survive validation now that it is applied at startup.
+    "accept quoted keyspace and table names in JournalSettings" in {
+      val quotedConfig = ConfigFactory.parseString("""
+          |journal.keyspace = "\"My Keyspace\""
+          |journal.table = "\"my-messages\""
+        """.stripMargin).withFallback(defaultConfig)
+      val config = new JournalSettings(system, quotedConfig)
+      config.keyspace must be("\"My Keyspace\"")
+      config.table must be("\"my-messages\"")
+    }
+
+    "accept a quoted table name in SnapshotSettings" in {
+      val quotedConfig = ConfigFactory.parseString("""
+          |snapshot.table = "\"my-snapshots\""
+        """.stripMargin).withFallback(defaultConfig)
+      val config = new SnapshotSettings(system, quotedConfig)
+      config.table must be("\"my-snapshots\"")
+    }
+
+    "accept a quoted tag table name in EventsByTagSettings" in {
+      val quotedConfig = ConfigFactory.parseString("""
+          |events-by-tag.table = "\"my-tag-views\""
+        """.stripMargin).withFallback(defaultConfig)
+      val config = new EventsByTagSettings(system, quotedConfig)
+      config.tagTable.name must be("\"my-tag-views\"")
     }
 
     "parse keyspace-autocreate parameter" in {


### PR DESCRIPTION
### Motivation

`PluginSettings.validateKeyspaceName` and `PluginSettings.validateTableName` existed but had **no production call sites** — they were only ever exercised from `CassandraPluginSettingsSpec`. Every configurable keyspace and table name flowed straight from config into interpolated CQL strings with no checking, so a malformed identifier surfaced as an opaque CQL syntax error at DDL or query time rather than as a clear configuration error at startup.

Enforcing the validators at settings-initialisation time requires the regex behind them to agree with Cassandra's actual identifier grammar. The original regex did not:

```
^("[a-zA-Z]{1}[\w]{0,47}"|[a-zA-Z]{1}[\w]{0,47})$
```

The quoted alternative required the quoted content to look like an unquoted identifier. That defeats the point of quoting: CQL quoted identifiers are case-sensitive and may contain characters (spaces, hyphens, reserved words) that are illegal unquoted. Turning validation on with that regex in place would have **broken existing deployments** that legitimately configure a quoted table or keyspace name.

The accompanying error messages were also wrong — they claimed a 32-character limit while the regex allowed 48.

### Modification

**Wire the validators into the settings classes**, so a bad identifier fails fast with `IllegalArgumentException` at startup:

- `JournalSettings` — `keyspace`, `table`, `metadata-table`, `all-persistence-ids-table`
- `SnapshotSettings` — `keyspace`, `table`
- `EventsByTagSettings` — `table`

This covers every configurable identifier; the tag progress and tag scanning table names are hardcoded.

**Relax the quoted alternative** so that quoted identifiers are accepted as CQL defines them, and **keep the unquoted alternative strict**:

```
^([a-zA-Z][a-zA-Z0-9_]{0,47}|"[^"]{1,48}")$
```

- Unquoted: must start with a letter, then letters/digits/underscores, 48 characters max — matching CQL's `IDENT: LETTER (LETTER | DIGIT | '_')*` and Cassandra's 48-character limit.
- Quoted: any content except a double quote, 1 to 48 characters. An embedded escaped quote (`""`) is deliberately not supported; it is not a realistic table name and the restriction keeps the pattern simple.

This is not an injection vector: the whole value becomes a single quoted CQL identifier, and Cassandra does not accept multi-statement queries.

**Correct the error messages** to state the real rules — leading letter, 48 characters, and the quoted alternative.

### Result

- Malformed keyspace and table names are rejected at startup with a message that names the offending setting and value, instead of failing later as a CQL syntax error.
- The validator now accepts exactly what Cassandra accepts. In particular a leading underscore (`_test_123`, `_`) is rejected, since CQL requires unquoted identifiers to begin with a letter.
- Deployments using quoted, case-sensitive identifiers keep working; they would have been rejected under the original regex once validation was enforced.
- No behaviour change for the default configuration or for any name Cassandra would have accepted.

### Tests

- `sbt "core/testOnly org.apache.pekko.persistence.cassandra.CassandraPluginSettingsSpec"` — 21 passed
- `sbt +mimaReportBinaryIssues` — no binary compatibility issues
- `sbt "+core/Test/compile"` — compiles on Scala 2.13.18 and 3.3.8
- `sbt scalafmtAll scalafmtSbt headerCreateAll` — clean, no further changes
- Cassandra integration tests — Not run, no Cassandra cluster available in this environment

Test coverage added:

- The validation table now asserts the leading-letter rule (`_test_123`, `_` invalid) and that quoted identifiers containing hyphens and spaces are valid.
- `validate table name parameter` now calls `validateTableName` (it previously called `validateKeyspaceName`, leaving `validateTableName` uncovered) and asserts the message identifies a table.
- Rejection tests for each newly validated setting in `JournalSettings`, `SnapshotSettings` and `EventsByTagSettings`.
- Acceptance tests confirming quoted identifiers survive validation in all three settings classes.

### References

None - hardening of existing configuration handling; no linked issue.
