### PR TITLE
add max-buffer-size for tag writing

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -250,6 +250,13 @@ pekko.persistence.cassandra {
     # size and this should be reduced if that warning is seen.
     max-message-batch-size = 150
 
+    # Hard upper bound on the number of events buffered per tag writer.
+    # When this limit is exceeded, new writes are rejected and the journal will retry.
+    # This prevents unbounded memory growth when Cassandra is slow or unresponsive.
+    # Set to -1 for no limit (not recommended for production).
+    # Must be greater than max-message-batch-size.
+    max-buffer-size = 50000
+
     # Max time to buffer events for before writing.
     # Larger values will increase cassandra write efficiency but increase the delay before
     # seeing events in EventsByTag queries.

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -250,12 +250,22 @@ pekko.persistence.cassandra {
     # size and this should be reduced if that warning is seen.
     max-message-batch-size = 150
 
-    # Hard upper bound on the number of events buffered per tag writer.
-    # When this limit is exceeded, new writes are rejected and the journal will retry.
-    # This prevents unbounded memory growth when Cassandra is slow or unresponsive.
-    # Set to -1 for no limit (not recommended for production).
-    # Must be greater than max-message-batch-size.
-    max-buffer-size = 50000
+    # Hard upper bound on the number of events buffered by a single tag writer.
+    # Set to 0 (the default) for no limit, which is the behaviour of earlier versions.
+    #
+    # Normal writes are already bounded: the journal waits for the tag write to be
+    # acknowledged, so a persistent actor has at most one write outstanding. Recovery
+    # sends tag writes without waiting for acknowledgement, so a persistence id with a
+    # lot of tagged events to replay is what can make this buffer grow.
+    #
+    # When the limit is reached the tag write is rejected and the failure is returned to
+    # the journal, which fails the write for that persistent actor. Nothing is silently
+    # dropped: rejected events consume no tag pid sequence nrs and are written by tag
+    # scanning when the persistent actor next recovers. Enable this only if an unbounded
+    # buffer is an actual risk for you, as the rejection stops persistent actors.
+    #
+    # Should be comfortably larger than max-message-batch-size.
+    max-buffer-size = 0
 
     # Max time to buffer events for before writing.
     # Larger values will increase cassandra write efficiency but increase the delay before

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -251,7 +251,8 @@ pekko.persistence.cassandra {
     max-message-batch-size = 150
 
     # Hard upper bound on the number of events buffered by a single tag writer.
-    # Set to 0 (the default) for no limit, which is the behaviour of earlier versions.
+    # Set to "unlimited" (the default), "off" or 0 for no limit, which is the
+    # behaviour of earlier versions.
     #
     # Normal writes are already bounded: the journal waits for the tag write to be
     # acknowledged, so a persistent actor has at most one write outstanding. Recovery
@@ -265,7 +266,7 @@ pekko.persistence.cassandra {
     # buffer is an actual risk for you, as the rejection stops persistent actors.
     #
     # Should be comfortably larger than max-message-batch-size.
-    max-buffer-size = 0
+    max-buffer-size = unlimited
 
     # Max time to buffer events for before writing.
     # Larger values will increase cassandra write efficiency but increase the delay before

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/EventsByTagSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/EventsByTagSettings.scala
@@ -155,6 +155,7 @@ import com.typesafe.config.Config
 
   val tagWriterSettings = TagWriterSettings(
     eventsByTagConfig.getInt("max-message-batch-size"),
+    eventsByTagConfig.getInt("max-buffer-size"),
     eventsByTagConfig.getDuration("flush-interval", TimeUnit.MILLISECONDS).millis,
     eventsByTagConfig.getDuration("scanning-flush-interval", TimeUnit.MILLISECONDS).millis,
     eventsByTagConfig.getDuration("stop-tag-writer-when-idle", TimeUnit.MILLISECONDS).millis,

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/EventsByTagSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/EventsByTagSettings.scala
@@ -153,9 +153,11 @@ import com.typesafe.config.Config
 
   val tagWriteTimeout = eventsByTagConfig.getDuration("tag-write-timeout", TimeUnit.MILLISECONDS).millis
 
+  val maxBufferSize: Int = unlimitedInt(eventsByTagConfig, "max-buffer-size")
+
   val tagWriterSettings = TagWriterSettings(
     eventsByTagConfig.getInt("max-message-batch-size"),
-    eventsByTagConfig.getInt("max-buffer-size"),
+    maxBufferSize,
     eventsByTagConfig.getDuration("flush-interval", TimeUnit.MILLISECONDS).millis,
     eventsByTagConfig.getDuration("scanning-flush-interval", TimeUnit.MILLISECONDS).millis,
     eventsByTagConfig.getDuration("stop-tag-writer-when-idle", TimeUnit.MILLISECONDS).millis,
@@ -217,6 +219,16 @@ import com.typesafe.config.Config
     eventsByTagConfig.getDouble("retries.random-factor"))
 
   val maxMissingToSearch: Long = eventsByTagConfig.getLong("max-missing-to-search")
+
+  /**
+   * An int setting where no limit can be spelled either as `0` or as `unlimited`/`off`. Returns `0` for no limit.
+   */
+  private def unlimitedInt(cfg: Config, path: String): Int = {
+    cfg.getString(path).toLowerCase match {
+      case "unlimited" | "off" | "false" => 0
+      case _                             => cfg.getInt(path)
+    }
+  }
 
   private def optionalDuration(cfg: Config, path: String): Option[FiniteDuration] = {
     cfg.getString(path).toLowerCase match {

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/Buffer.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/Buffer.scala
@@ -42,6 +42,9 @@ private[pekko] case class Buffer(
 
   def nonEmpty: Boolean = nextBatch.nonEmpty
 
+  /** Number of events waiting in the pending queue (not including the current batch being written) */
+  def pendingSize: Int = pending.foldLeft(0)((acc, w) => acc + w.events.size)
+
   def remove(pid: String): Buffer = {
     val (toFilter, without) = nextBatch.partition(_.events.head._1.persistenceId == pid)
     val filteredPending = pending.filterNot(_.events.head._1.persistenceId == pid)

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/Buffer.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/Buffer.scala
@@ -42,13 +42,10 @@ private[pekko] case class Buffer(
 
   def nonEmpty: Boolean = nextBatch.nonEmpty
 
-  /** Number of events waiting in the pending queue (not including the current batch being written) */
-  def pendingSize: Int = pending.foldLeft(0)((acc, w) => acc + w.events.size)
-
   def remove(pid: String): Buffer = {
     val (toFilter, without) = nextBatch.partition(_.events.head._1.persistenceId == pid)
-    val filteredPending = pending.filterNot(_.events.head._1.persistenceId == pid)
-    val removed = toFilter.foldLeft(0)((acc, next) => acc + next.events.size)
+    val (removedPending, filteredPending) = pending.partition(_.events.head._1.persistenceId == pid)
+    val removed = Buffer.eventCount(toFilter) + Buffer.eventCount(removedPending)
     copy(size = size - removed, nextBatch = without, pending = filteredPending)
   }
 
@@ -83,7 +80,7 @@ private[pekko] case class Buffer(
         // rare case where events have been received out of order, just re-build the buffer
         require(pending.isEmpty)
         val allWrites = (nextBatch :+ write).sortBy(_.events.head._1.timeUuid)(timeUuidOrdering)
-        rebuild(allWrites)
+        rebuild(allWrites, newSize)
       } else if (nextBatch.headOption.exists(_.events.head._1.timeBucket != write.events.head._1.timeBucket)) {
         // time bucket has changed
         copy(size = newSize, pending = pending :+ write, writeRequired = true)
@@ -107,7 +104,12 @@ private[pekko] case class Buffer(
     }
   }
 
-  private def rebuild(writes: Vector[AwaitingWrite]): Buffer = {
+  /**
+   * `totalSize` is the number of events in `writes`. It is passed in rather than counted here because
+   * `writes` can be very large when the database is falling behind, and this runs on every completed
+   * write.
+   */
+  private def rebuild(writes: Vector[AwaitingWrite], totalSize: Int): Buffer = {
     var buffer = Buffer.empty(batchSize)
     var i = 0
     while (!buffer.shouldWrite() && i < writes.size) {
@@ -115,7 +117,7 @@ private[pekko] case class Buffer(
       i += 1
     }
     //       pending may have one in it as the last one may have been a time bucket change rather than bach full
-    val done = buffer.copy(pending = buffer.pending ++ writes.drop(i))
+    val done = buffer.copy(size = totalSize, pending = buffer.pending ++ writes.drop(i))
     done
   }
 
@@ -126,7 +128,8 @@ private[pekko] case class Buffer(
   def writeComplete(): Buffer = {
     // this could be more efficient by adding until a write is required but this is simpler and
     // pending is expected to be small unless the database is falling behind
-    rebuild(pending)
+    // nextBatch has just been written and is bounded by batchSize, so what is left is the rest of size
+    rebuild(pending, size - Buffer.eventCount(nextBatch))
   }
 }
 
@@ -135,6 +138,10 @@ private[pekko] case class Buffer(
  */
 @InternalApi
 private[pekko] object Buffer {
+
+  private def eventCount(writes: Vector[AwaitingWrite]): Int =
+    writes.foldLeft(0)((acc, next) => acc + next.events.size)
+
   def empty(batchSize: Int): Buffer = {
     require(batchSize > 0)
     Buffer(batchSize, 0, Vector.empty, Vector.empty, writeRequired = false)

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/TagWriter.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/TagWriter.scala
@@ -224,13 +224,14 @@ import scala.util.{ Failure, Success, Try }
       val (updatedTagPidSequenceNrs, events) =
         assignTagPidSequenceNumbers(payload.toVector, tagPidSequenceNrs)
       val now = System.nanoTime()
-      // Check hard upper bound first
-      if (settings.maxBufferSize > 0 && buffer.size >= settings.maxBufferSize) {
+      // Check hard upper bound - only count pending events, not the batch being written
+      val currentPendingSize = buffer.pendingSize
+      if (settings.maxBufferSize > 0 && currentPendingSize >= settings.maxBufferSize) {
         log.error(
           "Tag writer buffer full ({} >= {}). Rejecting write for tag [{}]. " +
           "This indicates Cassandra is not keeping up with writes. " +
           "The journal will retry after the tag-write-timeout.",
-          buffer.size,
+          currentPendingSize,
           settings.maxBufferSize,
           tag)
         // Don't buffer - the sender's ask will timeout and the journal will retry

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/TagWriter.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/TagWriter.scala
@@ -53,6 +53,7 @@ import scala.util.{ Failure, Success, Try }
 
   private[pekko] case class TagWriterSettings(
       maxBatchSize: Int,
+      maxBufferSize: Int,
       flushInterval: FiniteDuration,
       scanningFlushInterval: FiniteDuration,
       stopTagWriterWhenIdle: FiniteDuration,
@@ -174,9 +175,21 @@ import scala.util.{ Failure, Success, Try }
       val (newTagPidSequenceNrs, events: Seq[(Serialized, TagPidSequenceNr)]) = {
         assignTagPidSequenceNumbers(payload.toVector, tagPidSequenceNrs)
       }
-      val newWrite = AwaitingWrite(events, OptionVal(sender()))
-      val newBuffer = buffer.add(newWrite)
-      flushIfRequired(newBuffer, newTagPidSequenceNrs)
+      // Check hard upper bound first
+      if (settings.maxBufferSize > 0 && buffer.size >= settings.maxBufferSize) {
+        log.error(
+          "Tag writer buffer full ({} >= {}). Rejecting write for tag [{}]. " +
+          "This indicates Cassandra is not keeping up with writes. " +
+          "The journal will retry after the tag-write-timeout.",
+          buffer.size,
+          settings.maxBufferSize,
+          tag)
+        // Don't buffer - the sender's ask will timeout and the journal will retry
+      } else {
+        val newWrite = AwaitingWrite(events, OptionVal(sender()))
+        val newBuffer = buffer.add(newWrite)
+        flushIfRequired(newBuffer, newTagPidSequenceNrs)
+      }
     case twd: TagWriteDone =>
       log.error("Received Done when in idle state. This is a bug. Please report with DEBUG logs: {}", twd)
     case ResetPersistenceId(_, tp @ TagProgress(pid, _, tagPidSequenceNr)) =>
@@ -210,20 +223,33 @@ import scala.util.{ Failure, Success, Try }
     case TagWrite(_, payload, _) =>
       val (updatedTagPidSequenceNrs, events) =
         assignTagPidSequenceNumbers(payload.toVector, tagPidSequenceNrs)
-      val awaitingWrite = AwaitingWrite(events, OptionVal(sender()))
       val now = System.nanoTime()
-      if (buffer.size > (4 * settings.maxBatchSize) && now > (lastLoggedBufferNs + bufferWarningMinDurationNs)) {
-        lastLoggedBufferNs = now
-        log.warning(
-          "Buffer for tagged events is getting too large ({}), is Cassandra responsive? Are writes failing? " +
-          "If events are buffered for longer than the eventual-consistency-delay they won't be picked up by live queries. The oldest event in the buffer is offset: {}",
+      // Check hard upper bound first
+      if (settings.maxBufferSize > 0 && buffer.size >= settings.maxBufferSize) {
+        log.error(
+          "Tag writer buffer full ({} >= {}). Rejecting write for tag [{}]. " +
+          "This indicates Cassandra is not keeping up with writes. " +
+          "The journal will retry after the tag-write-timeout.",
           buffer.size,
-          formatOffset(buffer.nextBatch.head.events.head._1.timeUuid))
+          settings.maxBufferSize,
+          tag)
+        // Don't buffer - the sender's ask will timeout and the journal will retry
+        // This creates backpressure on the journal
+      } else {
+        val awaitingWrite = AwaitingWrite(events, OptionVal(sender()))
+        if (buffer.size > (4 * settings.maxBatchSize) && now > (lastLoggedBufferNs + bufferWarningMinDurationNs)) {
+          lastLoggedBufferNs = now
+          log.warning(
+            "Buffer for tagged events is getting too large ({}), is Cassandra responsive? Are writes failing? " +
+            "If events are buffered for longer than the eventual-consistency-delay they won't be picked up by live queries. The oldest event in the buffer is offset: {}",
+            buffer.size,
+            formatOffset(buffer.nextBatch.head.events.head._1.timeUuid))
+        }
+        // buffer until current query is finished
+        // Don't sort until the write has finished
+        val newBuffer = buffer.addPending(awaitingWrite)
+        become(writeInProgress(newBuffer, updatedTagPidSequenceNrs, awaitingFlush))
       }
-      // buffer until current query is finished
-      // Don't sort until the write has finished
-      val newBuffer = buffer.addPending(awaitingWrite)
-      become(writeInProgress(newBuffer, updatedTagPidSequenceNrs, awaitingFlush))
     case TagWriteDone(summary, doneNotify) =>
       log.debug("Tag write done: {}", summary)
       val nextBuffer = buffer.writeComplete()

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/TagWriter.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/TagWriter.scala
@@ -17,7 +17,16 @@ import java.util.UUID
 
 import org.apache.pekko
 import pekko.Done
-import pekko.actor.{ Actor, ActorLogging, ActorRef, NoSerializationVerificationNeeded, Props, ReceiveTimeout, Timers }
+import pekko.actor.{
+  Actor,
+  ActorLogging,
+  ActorRef,
+  NoSerializationVerificationNeeded,
+  Props,
+  ReceiveTimeout,
+  Status,
+  Timers
+}
 import pekko.annotation.InternalApi
 import pekko.cluster.pubsub.{ DistributedPubSub, DistributedPubSubMediator }
 import pekko.event.LoggingAdapter
@@ -29,6 +38,7 @@ import pekko.persistence.cassandra.journal.TagWriters.TagWritersSession
 import pekko.util.{ OptionVal, UUIDComparator }
 
 import scala.concurrent.duration.{ Duration, FiniteDuration, _ }
+import scala.util.control.NoStackTrace
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
@@ -43,13 +53,23 @@ import scala.util.{ Failure, Success, Try }
  * Prevents any concurrent writes.
  *
  * Possible improvements:
- * - Max buffer size
  * - Optimize sorting given they are nearly sorted
  */
 @InternalApi private[pekko] object TagWriter {
 
   private[pekko] def props(settings: TagWriterSettings, session: TagWritersSession, tag: Tag, parent: ActorRef): Props =
     Props(new TagWriter(settings, session, tag, parent))
+
+  /**
+   * Returned to the sender when a tag write can not be buffered because `max-buffer-size` has been
+   * reached. The write is not buffered and no tag pid sequence nrs are consumed by it, so the events
+   * are picked up again by tag scanning when the persistent actor next recovers.
+   */
+  private[pekko] final class TagWriterBufferFullException(val tag: Tag, val bufferSize: Int, val maxBufferSize: Int)
+      extends RuntimeException(
+        s"Tag write for tag [$tag] rejected, buffer is full [$bufferSize >= $maxBufferSize]. " +
+        "Cassandra is not keeping up with tagged writes.")
+      with NoStackTrace
 
   private[pekko] case class TagWriterSettings(
       maxBatchSize: Int,
@@ -144,6 +164,30 @@ import scala.util.{ Failure, Success, Try }
 
   var lastLoggedBufferNs: Long = -1
   val bufferWarningMinDurationNs: Long = 5.seconds.toNanos
+  var lastLoggedBufferFullNs: Long = -1
+
+  private def bufferFull(buffer: Buffer): Boolean =
+    settings.maxBufferSize > 0 && buffer.size >= settings.maxBufferSize
+
+  /**
+   * Fails the sender's ask rather than dropping the write silently, so that the journal sees the
+   * rejection straight away instead of waiting out `tag-write-timeout`. Nothing is buffered and no tag
+   * pid sequence nrs are consumed, so the events are not lost: tag scanning picks them up when the
+   * persistent actor next recovers.
+   */
+  private def rejectWrite(buffer: Buffer, replyTo: ActorRef): Unit = {
+    val now = System.nanoTime()
+    if (now > (lastLoggedBufferFullNs + bufferWarningMinDurationNs)) {
+      lastLoggedBufferFullNs = now
+      log.error(
+        "Buffer for tagged events is full ({} >= {}) for tag [{}], rejecting writes. Is Cassandra responsive? " +
+        "Are writes failing? Rejected events will be written by tag scanning when the persistent actor recovers.",
+        buffer.size,
+        settings.maxBufferSize,
+        tag)
+    }
+    replyTo ! Status.Failure(new TagWriter.TagWriterBufferFullException(tag, buffer.size, settings.maxBufferSize))
+  }
 
   override def preStart(): Unit = {
     log.debug("Running TagWriter for [{}] with settings {}", tag, settings)
@@ -172,20 +216,13 @@ import scala.util.{ Failure, Success, Try }
         sender() ! FlushComplete
       }
     case TagWrite(_, payload, _) =>
-      val (newTagPidSequenceNrs, events: Seq[(Serialized, TagPidSequenceNr)]) = {
-        assignTagPidSequenceNumbers(payload.toVector, tagPidSequenceNrs)
-      }
-      // Check hard upper bound first
-      if (settings.maxBufferSize > 0 && buffer.size >= settings.maxBufferSize) {
-        log.error(
-          "Tag writer buffer full ({} >= {}). Rejecting write for tag [{}]. " +
-          "This indicates Cassandra is not keeping up with writes. " +
-          "The journal will retry after the tag-write-timeout.",
-          buffer.size,
-          settings.maxBufferSize,
-          tag)
-        // Don't buffer - the sender's ask will timeout and the journal will retry
+      // checked before any tag pid sequence nrs are assigned so that a rejected write consumes none
+      if (bufferFull(buffer)) {
+        rejectWrite(buffer, sender())
       } else {
+        val (newTagPidSequenceNrs, events: Seq[(Serialized, TagPidSequenceNr)]) = {
+          assignTagPidSequenceNumbers(payload.toVector, tagPidSequenceNrs)
+        }
         val newWrite = AwaitingWrite(events, OptionVal(sender()))
         val newBuffer = buffer.add(newWrite)
         flushIfRequired(newBuffer, newTagPidSequenceNrs)
@@ -221,22 +258,13 @@ import scala.util.{ Failure, Success, Try }
       log.debug("External flush while write in progress. Will flush after write complete")
       become(writeInProgress(buffer, tagPidSequenceNrs, Some(sender())))
     case TagWrite(_, payload, _) =>
-      val (updatedTagPidSequenceNrs, events) =
-        assignTagPidSequenceNumbers(payload.toVector, tagPidSequenceNrs)
-      val now = System.nanoTime()
-      // Check hard upper bound - only count pending events, not the batch being written
-      val currentPendingSize = buffer.pendingSize
-      if (settings.maxBufferSize > 0 && currentPendingSize >= settings.maxBufferSize) {
-        log.error(
-          "Tag writer buffer full ({} >= {}). Rejecting write for tag [{}]. " +
-          "This indicates Cassandra is not keeping up with writes. " +
-          "The journal will retry after the tag-write-timeout.",
-          currentPendingSize,
-          settings.maxBufferSize,
-          tag)
-        // Don't buffer - the sender's ask will timeout and the journal will retry
-        // This creates backpressure on the journal
+      // checked before any tag pid sequence nrs are assigned so that a rejected write consumes none
+      if (bufferFull(buffer)) {
+        rejectWrite(buffer, sender())
       } else {
+        val (updatedTagPidSequenceNrs, events) =
+          assignTagPidSequenceNumbers(payload.toVector, tagPidSequenceNrs)
+        val now = System.nanoTime()
         val awaitingWrite = AwaitingWrite(events, OptionVal(sender()))
         if (buffer.size > (4 * settings.maxBatchSize) && now > (lastLoggedBufferNs + bufferWarningMinDurationNs)) {
           lastLoggedBufferNs = now

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraPluginSettingsSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraPluginSettingsSpec.scala
@@ -149,4 +149,26 @@ class CassandraPluginSettingsSpec
     }
   }
 
+  "An EventsByTagSettings" must {
+
+    def settingsWithMaxBufferSize(value: String): EventsByTagSettings =
+      new EventsByTagSettings(
+        system,
+        ConfigFactory.parseString(s"events-by-tag.max-buffer-size = $value").withFallback(defaultConfig))
+
+    "default max-buffer-size to no limit" in {
+      new EventsByTagSettings(system, defaultConfig).maxBufferSize must be(0)
+    }
+
+    "parse max-buffer-size as a number" in {
+      settingsWithMaxBufferSize("100000").maxBufferSize must be(100000)
+    }
+
+    "parse max-buffer-size no limit aliases" in {
+      forAll(Table("value", "unlimited", "UNLIMITED", "off", "false", "0")) { value =>
+        settingsWithMaxBufferSize(value).maxBufferSize must be(0)
+      }
+    }
+  }
+
 }

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/BufferSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/BufferSpec.scala
@@ -183,6 +183,38 @@ class BufferSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
       }
       writes shouldEqual totalWrites / 2
     }
+
+    // size is what the tag writer reports and limits on, so it has to stay equal to the number of
+    // events actually held in nextBatch plus pending
+    "keep size accurate when a write completes with events still pending" in {
+      val bucket = nowBucket()
+      var buffer = Buffer.empty(2)
+      for (i <- 1 to 5) {
+        buffer = buffer.add(awNoSender((event("p1", seqNr = i, payload = "cats", bucket), i)))
+      }
+      buffer.size shouldEqual 5
+
+      // two events are written, leaving three, of which one does not fit in the rebuilt batch
+      val afterWrite = buffer.writeComplete()
+      afterWrite.size shouldEqual 3
+      afterWrite.nextBatch.map(_.events.size).sum + afterWrite.pending.map(_.events.size).sum shouldEqual 3
+    }
+
+    "keep size accurate when a persistence id with pending events is removed" in {
+      val bucket = nowBucket()
+      val buffer = Buffer
+        .empty(2)
+        .add(awNoSender((event("p1", seqNr = 1, payload = "cats", bucket), 1)))
+        .add(awNoSender((event("p1", seqNr = 2, payload = "cats", bucket), 2)))
+        .add(awNoSender((event("p2", seqNr = 1, payload = "dogs", bucket), 1)))
+        .add(awNoSender((event("p1", seqNr = 3, payload = "cats", bucket), 3)))
+      buffer.size shouldEqual 4
+
+      // removes two from nextBatch and one from pending, leaving only p2
+      val afterRemove = buffer.remove("p1")
+      afterRemove.size shouldEqual 1
+      afterRemove.nextBatch.map(_.events.size).sum + afterRemove.pending.map(_.events.size).sum shouldEqual 1
+    }
   }
 
   override protected def afterAll(): Unit = {

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/TagWriterSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/TagWriterSpec.scala
@@ -78,6 +78,7 @@ class TagWriterSpec
   val successfulWrite: Statement[?] => Future[Done] = _ => Future.successful(Done)
   val defaultSettings = TagWriterSettings(
     maxBatchSize = 10,
+    maxBufferSize = 50000,
     flushInterval = 10.seconds,
     scanningFlushInterval = 20.seconds,
     stopTagWriterWhenIdle = 5.seconds,

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/TagWriterSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/TagWriterSpec.scala
@@ -17,7 +17,7 @@ import java.nio.ByteBuffer
 import java.util.UUID
 import org.apache.pekko
 import pekko.Done
-import pekko.actor.{ ActorRef, ActorSystem }
+import pekko.actor.{ ActorRef, ActorSystem, Status }
 import pekko.event.Logging
 import pekko.event.Logging.Warning
 import pekko.persistence.cassandra.Day
@@ -79,7 +79,7 @@ class TagWriterSpec
   val successfulWrite: Statement[?] => Future[Done] = _ => Future.successful(Done)
   val defaultSettings = TagWriterSettings(
     maxBatchSize = 10,
-    maxBufferSize = 50000,
+    maxBufferSize = 0,
     flushInterval = 10.seconds,
     scanningFlushInterval = 20.seconds,
     stopTagWriterWhenIdle = 5.seconds,
@@ -103,6 +103,11 @@ class TagWriterSpec
     val sender = TestProbe()
     implicit val senderRef: ActorRef = sender.ref
   }
+
+  private def expectBufferFullLogged(): Unit =
+    logProbe.expectMsgPF(waitDuration) {
+      case Logging.Error(_, _, _, msg) if msg.toString.contains("Buffer for tagged events is full") => ()
+    }
 
   "Tag writer batching" must {
 
@@ -676,143 +681,124 @@ class TagWriterSpec
 
   "Tag writer buffer limit" must {
 
-    "reject writes when buffer is full in idle state" in new Setup {
-      // Use large maxBatchSize to prevent auto-flushing; small maxBufferSize to trigger rejection
+    "reject a write and fail the sender when the buffer is full" in new Setup {
       val (probe, ref) =
-        setup(settings = defaultSettings.copy(maxBatchSize = 100, maxBufferSize = 2, flushInterval = 1.hour))
+        setup(settings = defaultSettings.copy(maxBatchSize = 100, maxBufferSize = 1, flushInterval = 1.hour))
       val bucket = nowBucket()
-
       val e1 = event("p1", 1L, "e-1", bucket)
       val e2 = event("p2", 1L, "e-2", bucket)
-      val e3 = event("p3", 1L, "e-3", bucket)
 
-      // First two writes should be accepted (buffer.size 0->1->2)
+      // fills the buffer, nothing is written yet as the batch is not full
       ref ! TagWrite(tagName, Vector(e1))
+      probe.expectNoMessage(waitDuration)
+
       ref ! TagWrite(tagName, Vector(e2))
+      val failure = sender.expectMsgType[Status.Failure]
+      assert(failure.cause.isInstanceOf[TagWriter.TagWriterBufferFullException])
       probe.expectNoMessage(waitDuration)
-
-      // Third write should be rejected (buffer.size 2 >= maxBufferSize 2)
-      ref ! TagWrite(tagName, Vector(e3))
-
-      // Should see error log about buffer being full
-      logProbe.expectMsgPF(waitDuration) {
-        case Logging.Error(_, _, _, msg) if msg.toString.contains("Tag writer buffer full") =>
-      }
-
-      // The rejected write should not be processed
-      probe.expectNoMessage(waitDuration)
-      logProbe.expectNoMessage(waitDuration)
+      expectBufferFullLogged()
     }
 
-    "reject writes when buffer is full in writeInProgress state" in new Setup {
+    "reject a write and fail the sender when the buffer is full during a write" in new Setup {
       val writePromise = Promise[Done]()
-      // Use maxBatchSize=1 so first event triggers an immediate write
       val (probe, ref) = setup(
-        settings = defaultSettings.copy(maxBatchSize = 1, maxBufferSize = 1, flushInterval = 1.hour),
+        settings = defaultSettings.copy(maxBatchSize = 1, maxBufferSize = 2, flushInterval = 1.hour),
         writeResponse = LazyList(writePromise.future) ++ LazyList.continually(Future.successful(Done)))
       val bucket = nowBucket()
-
       val e1 = event("p1", 1L, "e-1", bucket)
       val e2 = event("p2", 1L, "e-2", bucket)
       val e3 = event("p3", 1L, "e-3", bucket)
 
-      // First write triggers immediate batch write (maxBatchSize=1)
+      // maxBatchSize is 1 so this write starts immediately and stays in the buffer while in flight
       ref ! TagWrite(tagName, Vector(e1))
       probe.expectMsg(Vector(toEw(e1, 1)))
 
-      // Second write is buffered in writeInProgress (buffer.size 0->1, below maxBufferSize=1)
+      // buffer holds the in flight batch, one more still fits
       ref ! TagWrite(tagName, Vector(e2))
       probe.expectNoMessage(waitDuration)
 
-      // Third write should be rejected (buffer.size 1 >= maxBufferSize 1)
       ref ! TagWrite(tagName, Vector(e3))
+      val failure = sender.expectMsgType[Status.Failure]
+      assert(failure.cause.isInstanceOf[TagWriter.TagWriterBufferFullException])
+      expectBufferFullLogged()
 
-      // Should see error log about buffer being full
-      logProbe.expectMsgPF(waitDuration) {
-        case Logging.Error(_, _, _, msg) if msg.toString.contains("Tag writer buffer full") =>
-      }
-
-      // Complete the first write; the buffered e2 should be written next
+      // the accepted write is unaffected by the rejection
       writePromise.success(Done)
+      sender.expectMsg(Done)
       probe.expectMsg(ProgressWrite("p1", 1, 1, e1.timeUuid))
       probe.expectMsg(Vector(toEw(e2, 1)))
       probe.expectMsg(ProgressWrite("p2", 1, 1, e2.timeUuid))
-      logProbe.expectNoMessage(waitDuration)
+      sender.expectMsg(Done)
     }
 
-    "accept writes when buffer is below limit" in new Setup {
-      // Use large maxBatchSize to prevent auto-flushing
+    "not consume a tag pid sequence nr for a rejected write" in new Setup {
       val (probe, ref) =
-        setup(settings = defaultSettings.copy(maxBatchSize = 100, maxBufferSize = 5, flushInterval = 1.hour))
+        setup(settings = defaultSettings.copy(maxBatchSize = 100, maxBufferSize = 1, flushInterval = 1.hour))
       val bucket = nowBucket()
-
       val e1 = event("p1", 1L, "e-1", bucket)
-      val e2 = event("p2", 1L, "e-2", bucket)
-      val e3 = event("p3", 1L, "e-3", bucket)
+      val e2 = event("p1", 2L, "e-2", bucket)
 
-      // All writes should be accepted (buffer.size goes 0->1->2->3, all below maxBufferSize=5)
       ref ! TagWrite(tagName, Vector(e1))
-      ref ! TagWrite(tagName, Vector(e2))
-      ref ! TagWrite(tagName, Vector(e3))
       probe.expectNoMessage(waitDuration)
 
-      // No error logs should appear
-      logProbe.expectNoMessage(waitDuration)
-    }
+      // rejected, so it must not take tag pid sequence nr 2
+      ref ! TagWrite(tagName, Vector(e2))
+      sender.expectMsgType[Status.Failure]
+      expectBufferFullLogged()
 
-    "allow writes after buffer drains below limit" in new Setup {
-      val writePromise = Promise[Done]()
-      val (probe, ref) = setup(
-        settings = defaultSettings.copy(maxBatchSize = 1, maxBufferSize = 1, flushInterval = 1.hour),
-        writeResponse = LazyList(writePromise.future) ++ LazyList.continually(Future.successful(Done)))
-      val bucket = nowBucket()
-
-      val e1 = event("p1", 1L, "e-1", bucket)
-      val e2 = event("p2", 1L, "e-2", bucket)
-      val e3 = event("p3", 1L, "e-3", bucket)
-
-      // First write triggers immediate batch write
-      ref ! TagWrite(tagName, Vector(e1))
+      ref ! Flush
       probe.expectMsg(Vector(toEw(e1, 1)))
-
-      // Second write buffered (buffer.size 0->1)
-      ref ! TagWrite(tagName, Vector(e2))
-      probe.expectNoMessage(waitDuration)
-
-      // Third write rejected (buffer.size 1 >= maxBufferSize 1)
-      ref ! TagWrite(tagName, Vector(e3))
-      logProbe.expectMsgPF(waitDuration) {
-        case Logging.Error(_, _, _, msg) if msg.toString.contains("Tag writer buffer full") =>
-      }
-
-      // Complete first write - e2 gets written, buffer drains
-      writePromise.success(Done)
       probe.expectMsg(ProgressWrite("p1", 1, 1, e1.timeUuid))
-      probe.expectMsg(Vector(toEw(e2, 1)))
-      probe.expectMsg(ProgressWrite("p2", 1, 1, e2.timeUuid))
+      sender.expectMsg(Done)
+      sender.expectMsg(FlushComplete)
 
-      // Now buffer is empty - a new write should be accepted
-      val e4 = event("p4", 1L, "e-4", bucket)
-      ref ! TagWrite(tagName, Vector(e4))
-      probe.expectMsg(Vector(toEw(e4, 1)))
-      probe.expectMsg(ProgressWrite("p4", 1, 1, e4.timeUuid))
-      logProbe.expectNoMessage(waitDuration)
+      // buffer has drained, the retry gets the sequence nr the rejected write did not take.
+      // a gap here would stall eventsByTag until tag_views was repaired
+      ref ! TagWrite(tagName, Vector(e2))
+      ref ! Flush
+      probe.expectMsg(Vector(toEw(e2, 2)))
+      probe.expectMsg(ProgressWrite("p1", 2, 2, e2.timeUuid))
+      sender.expectMsg(Done)
+      sender.expectMsg(FlushComplete)
     }
 
-    "not reject writes when maxBufferSize is 0 (disabled)" in new Setup {
-      // Use large maxBatchSize to prevent the "buffer too large" warning
+    "accept writes again once the buffer has drained" in new Setup {
+      val (probe, ref) =
+        setup(settings = defaultSettings.copy(maxBatchSize = 100, maxBufferSize = 1, flushInterval = 1.hour))
+      val bucket = nowBucket()
+      val e1 = event("p1", 1L, "e-1", bucket)
+      val e2 = event("p2", 1L, "e-2", bucket)
+      val e3 = event("p3", 1L, "e-3", bucket)
+
+      ref ! TagWrite(tagName, Vector(e1))
+      ref ! TagWrite(tagName, Vector(e2))
+      sender.expectMsgType[Status.Failure]
+      expectBufferFullLogged()
+
+      ref ! Flush
+      probe.expectMsg(Vector(toEw(e1, 1)))
+      probe.expectMsg(ProgressWrite("p1", 1, 1, e1.timeUuid))
+      sender.expectMsg(Done)
+      sender.expectMsg(FlushComplete)
+
+      ref ! TagWrite(tagName, Vector(e3))
+      ref ! Flush
+      probe.expectMsg(Vector(toEw(e3, 1)))
+      probe.expectMsg(ProgressWrite("p3", 1, 1, e3.timeUuid))
+      sender.expectMsg(Done)
+      sender.expectMsg(FlushComplete)
+    }
+
+    "not reject anything when max-buffer-size is 0" in new Setup {
       val (probe, ref) =
         setup(settings = defaultSettings.copy(maxBatchSize = 100, maxBufferSize = 0, flushInterval = 1.hour))
       val bucket = nowBucket()
 
-      // Send many writes - none should be rejected since maxBufferSize=0 disables the check
-      for (i <- 1 to 10) {
-        val e = event(s"p$i", 1L, s"e-$i", bucket)
-        ref ! TagWrite(tagName, Vector(e))
+      (1 to 10).foreach { i =>
+        ref ! TagWrite(tagName, Vector(event(s"p$i", 1L, s"e-$i", bucket)))
       }
 
-      // No error logs should appear
-      logProbe.expectNoMessage(waitDuration)
+      sender.expectNoMessage(waitDuration)
       probe.expectNoMessage(waitDuration)
     }
   }

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/TagWriterSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/TagWriterSpec.scala
@@ -18,6 +18,7 @@ import java.util.UUID
 import org.apache.pekko
 import pekko.Done
 import pekko.actor.{ ActorRef, ActorSystem }
+import pekko.event.Logging
 import pekko.event.Logging.Warning
 import pekko.persistence.cassandra.Day
 import pekko.persistence.cassandra.journal.CassandraJournal._
@@ -671,6 +672,149 @@ class TagWriterSpec
       promiseForWrite.success(Done)
     }
 
+  }
+
+  "Tag writer buffer limit" must {
+
+    "reject writes when buffer is full in idle state" in new Setup {
+      // Use large maxBatchSize to prevent auto-flushing; small maxBufferSize to trigger rejection
+      val (probe, ref) =
+        setup(settings = defaultSettings.copy(maxBatchSize = 100, maxBufferSize = 2, flushInterval = 1.hour))
+      val bucket = nowBucket()
+
+      val e1 = event("p1", 1L, "e-1", bucket)
+      val e2 = event("p2", 1L, "e-2", bucket)
+      val e3 = event("p3", 1L, "e-3", bucket)
+
+      // First two writes should be accepted (buffer.size 0->1->2)
+      ref ! TagWrite(tagName, Vector(e1))
+      ref ! TagWrite(tagName, Vector(e2))
+      probe.expectNoMessage(waitDuration)
+
+      // Third write should be rejected (buffer.size 2 >= maxBufferSize 2)
+      ref ! TagWrite(tagName, Vector(e3))
+
+      // Should see error log about buffer being full
+      logProbe.expectMsgPF(waitDuration) {
+        case Logging.Error(_, _, _, msg) if msg.toString.contains("Tag writer buffer full") =>
+      }
+
+      // The rejected write should not be processed
+      probe.expectNoMessage(waitDuration)
+      logProbe.expectNoMessage(waitDuration)
+    }
+
+    "reject writes when buffer is full in writeInProgress state" in new Setup {
+      val writePromise = Promise[Done]()
+      // Use maxBatchSize=1 so first event triggers an immediate write
+      val (probe, ref) = setup(
+        settings = defaultSettings.copy(maxBatchSize = 1, maxBufferSize = 1, flushInterval = 1.hour),
+        writeResponse = LazyList(writePromise.future) ++ LazyList.continually(Future.successful(Done)))
+      val bucket = nowBucket()
+
+      val e1 = event("p1", 1L, "e-1", bucket)
+      val e2 = event("p2", 1L, "e-2", bucket)
+      val e3 = event("p3", 1L, "e-3", bucket)
+
+      // First write triggers immediate batch write (maxBatchSize=1)
+      ref ! TagWrite(tagName, Vector(e1))
+      probe.expectMsg(Vector(toEw(e1, 1)))
+
+      // Second write is buffered in writeInProgress (buffer.size 0->1, below maxBufferSize=1)
+      ref ! TagWrite(tagName, Vector(e2))
+      probe.expectNoMessage(waitDuration)
+
+      // Third write should be rejected (buffer.size 1 >= maxBufferSize 1)
+      ref ! TagWrite(tagName, Vector(e3))
+
+      // Should see error log about buffer being full
+      logProbe.expectMsgPF(waitDuration) {
+        case Logging.Error(_, _, _, msg) if msg.toString.contains("Tag writer buffer full") =>
+      }
+
+      // Complete the first write; the buffered e2 should be written next
+      writePromise.success(Done)
+      probe.expectMsg(ProgressWrite("p1", 1, 1, e1.timeUuid))
+      probe.expectMsg(Vector(toEw(e2, 1)))
+      probe.expectMsg(ProgressWrite("p2", 1, 1, e2.timeUuid))
+      logProbe.expectNoMessage(waitDuration)
+    }
+
+    "accept writes when buffer is below limit" in new Setup {
+      // Use large maxBatchSize to prevent auto-flushing
+      val (probe, ref) =
+        setup(settings = defaultSettings.copy(maxBatchSize = 100, maxBufferSize = 5, flushInterval = 1.hour))
+      val bucket = nowBucket()
+
+      val e1 = event("p1", 1L, "e-1", bucket)
+      val e2 = event("p2", 1L, "e-2", bucket)
+      val e3 = event("p3", 1L, "e-3", bucket)
+
+      // All writes should be accepted (buffer.size goes 0->1->2->3, all below maxBufferSize=5)
+      ref ! TagWrite(tagName, Vector(e1))
+      ref ! TagWrite(tagName, Vector(e2))
+      ref ! TagWrite(tagName, Vector(e3))
+      probe.expectNoMessage(waitDuration)
+
+      // No error logs should appear
+      logProbe.expectNoMessage(waitDuration)
+    }
+
+    "allow writes after buffer drains below limit" in new Setup {
+      val writePromise = Promise[Done]()
+      val (probe, ref) = setup(
+        settings = defaultSettings.copy(maxBatchSize = 1, maxBufferSize = 1, flushInterval = 1.hour),
+        writeResponse = LazyList(writePromise.future) ++ LazyList.continually(Future.successful(Done)))
+      val bucket = nowBucket()
+
+      val e1 = event("p1", 1L, "e-1", bucket)
+      val e2 = event("p2", 1L, "e-2", bucket)
+      val e3 = event("p3", 1L, "e-3", bucket)
+
+      // First write triggers immediate batch write
+      ref ! TagWrite(tagName, Vector(e1))
+      probe.expectMsg(Vector(toEw(e1, 1)))
+
+      // Second write buffered (buffer.size 0->1)
+      ref ! TagWrite(tagName, Vector(e2))
+      probe.expectNoMessage(waitDuration)
+
+      // Third write rejected (buffer.size 1 >= maxBufferSize 1)
+      ref ! TagWrite(tagName, Vector(e3))
+      logProbe.expectMsgPF(waitDuration) {
+        case Logging.Error(_, _, _, msg) if msg.toString.contains("Tag writer buffer full") =>
+      }
+
+      // Complete first write - e2 gets written, buffer drains
+      writePromise.success(Done)
+      probe.expectMsg(ProgressWrite("p1", 1, 1, e1.timeUuid))
+      probe.expectMsg(Vector(toEw(e2, 1)))
+      probe.expectMsg(ProgressWrite("p2", 1, 1, e2.timeUuid))
+
+      // Now buffer is empty - a new write should be accepted
+      val e4 = event("p4", 1L, "e-4", bucket)
+      ref ! TagWrite(tagName, Vector(e4))
+      probe.expectMsg(Vector(toEw(e4, 1)))
+      probe.expectMsg(ProgressWrite("p4", 1, 1, e4.timeUuid))
+      logProbe.expectNoMessage(waitDuration)
+    }
+
+    "not reject writes when maxBufferSize is 0 (disabled)" in new Setup {
+      // Use large maxBatchSize to prevent the "buffer too large" warning
+      val (probe, ref) =
+        setup(settings = defaultSettings.copy(maxBatchSize = 100, maxBufferSize = 0, flushInterval = 1.hour))
+      val bucket = nowBucket()
+
+      // Send many writes - none should be rejected since maxBufferSize=0 disables the check
+      for (i <- 1 to 10) {
+        val e = event(s"p$i", 1L, s"e-$i", bucket)
+        ref ! TagWrite(tagName, Vector(e))
+      }
+
+      // No error logs should appear
+      logProbe.expectNoMessage(waitDuration)
+      probe.expectNoMessage(waitDuration)
+    }
   }
 
   "Tag writer error scenarios" must {

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/TagWritersSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/TagWritersSpec.scala
@@ -54,6 +54,7 @@ class TagWritersSpec
 
   private val defaultSettings = TagWriterSettings(
     maxBatchSize = 10,
+    maxBufferSize = 50000,
     flushInterval = 10.seconds,
     scanningFlushInterval = 20.seconds,
     stopTagWriterWhenIdle = 5.seconds,

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/TagWritersSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/TagWritersSpec.scala
@@ -54,7 +54,7 @@ class TagWritersSpec
 
   private val defaultSettings = TagWriterSettings(
     maxBatchSize = 10,
-    maxBufferSize = 50000,
+    maxBufferSize = 0,
     flushInterval = 10.seconds,
     scanningFlushInterval = 20.seconds,
     stopTagWriterWhenIdle = 5.seconds,

--- a/docs/src/main/paradox/events-by-tag.md
+++ b/docs/src/main/paradox/events-by-tag.md
@@ -192,6 +192,30 @@ be taken not to have batches that will be rejected by Cassandra. Two other cases
 * Periodically: By default 250ms. To prevent eventsByTag queries being too out of date.
 * When a starting a new timebucket, which translates to a new partition in Cassandra, the events for the old timebucket are written.
 
+### Limiting the tag write buffer
+
+Each tag has a writer actor that buffers events until they are batched into a write. Normal writes are already
+bounded: the journal waits for the tag write to be acknowledged before completing the persist, so a persistent
+actor has at most one write outstanding. Recovery is different — it sends tag writes without waiting for
+acknowledgement, so a persistence id replaying a lot of tagged events is what can make the buffer grow.
+
+`max-buffer-size` puts a hard upper bound on the number of events one tag writer will hold. It is `0` by default,
+which means no limit.
+
+```
+pekko.persistence.cassandra.events-by-tag.max-buffer-size = 100000
+```
+
+When the limit is reached the tag write is rejected and the failure is returned to the journal, which fails the
+write for that persistent actor and stops it. Nothing is dropped silently: a rejected write consumes no tag pid
+sequence nrs, so it leaves no gap in `tag_views`, and the events are written by tag scanning when the persistent
+actor next recovers.
+
+That is a disruptive outcome, so only set this if an unbounded buffer is a real risk for you — it trades stopped
+persistent actors for bounded memory. Set it comfortably above `max-message-batch-size`, as the batch currently
+being written counts towards the buffer. The existing warning about the buffer getting too large is logged well
+before the limit is reached and is the signal to investigate first.
+
 ## Cleanup of tag_views table
 
 By default the tag_views table keeps tagged events indefinitely, even when the original events have been removed. 

--- a/docs/src/main/paradox/events-by-tag.md
+++ b/docs/src/main/paradox/events-by-tag.md
@@ -199,8 +199,8 @@ bounded: the journal waits for the tag write to be acknowledged before completin
 actor has at most one write outstanding. Recovery is different — it sends tag writes without waiting for
 acknowledgement, so a persistence id replaying a lot of tagged events is what can make the buffer grow.
 
-`max-buffer-size` puts a hard upper bound on the number of events one tag writer will hold. It is `0` by default,
-which means no limit.
+`max-buffer-size` puts a hard upper bound on the number of events one tag writer will hold. It is `unlimited` by
+default, which means no limit; `off` and `0` mean the same thing.
 
 ```
 pekko.persistence.cassandra.events-by-tag.max-buffer-size = 100000


### PR DESCRIPTION
### Motivation

Each tag has a writer actor that buffers events until they are batched into a write, with no upper bound on that buffer. `TagWriter`'s own class comment has listed "Max buffer size" as a possible improvement since the code was written.

Worth being precise about where the growth comes from, because it shapes the fix. Normal writes are already bounded: `CassandraJournal.asyncWriteMessages` waits for the tag write to be acknowledged, and `TagWriter` only acknowledges a write once its batch has been written, so a persistent actor has at most one write outstanding. Recovery is the unbounded path — `CassandraTagRecovery` sends tag writes with `!` and never waits for an acknowledgement, so a persistence id replaying a lot of tagged events is what can make the buffer grow.

### Modification

**Rejection is explicit rather than silent.** An over-limit write is answered with `Status.Failure(TagWriterBufferFullException)` naming the tag and the sizes. Dropping the message instead would leave the journal waiting out `tag-write-timeout` (4s by default) before failing the write anyway — `asyncWriteMessages` does `t.ask(extractTagWrites(...))` and `TagWriters.forwardTagWrite` uses `askTagActor`, and there is no retry anywhere on that path. Failing immediately turns a 4s stall per write into an attributable error.

**Nothing is lost when a write is rejected.** The limit is now checked *before* tag pid sequence numbers are assigned, in both the idle and write-in-progress branches, so a rejected write consumes none. A consumed sequence nr would leave a gap in `tag_views` that stalls `eventsByTag` until it is repaired. The events themselves are written by tag scanning when the persistent actor next recovers, because `TagWriters.forwardTagWrite` records the progress point before the ask.

**`Buffer.size` is fixed and used for the measurement.** It had two accounting bugs, which is why the first version of this PR added a separate `pendingSize`:

- `rebuild` carried leftover writes into `pending` without counting their events, so `size` undercounted after a write completed with events still pending;
- `remove` dropped a pid's pending writes without subtracting them, so `size` overcounted afterwards.

Both also affect the existing "buffer for tagged events is getting too large" warning, which has been under-reporting. `rebuild` now takes the total from the caller as arithmetic rather than folding over the pending vector — it runs on every completed write, and a fold there is quadratic when pending is large. `Buffer.pendingSize` is removed.

Both branches now measure `buffer.size`, which includes the batch currently being written. That batch is held in memory, so it counts towards the bound.

**The limit is off by default.** `max-buffer-size = 0` means no limit, so behaviour is unchanged unless it is opted into. Rejection stops persistent actors, and a deployment that today peaks above some threshold and drains without trouble should not start failing on upgrade. Documented in `events-by-tag.md` as a safety valve, with the note that the existing "buffer getting too large" warning fires well before the limit and is the signal to investigate first.

### Result

The tag write buffer can be bounded, and reaching the bound produces an immediate, attributable failure instead of a silent drop followed by a timeout. Rejected writes leave no gap in `tag_views` and are recovered by tag scanning. The `Buffer.size` fix also makes the pre-existing buffer-size warning accurate. Existing deployments are unaffected until they set `max-buffer-size`.

### Tests

These are all `TestKit` specs against a fake Cassandra session, so they run without a Cassandra instance.

- `TagWriterSpec`: rejection fails the sender with `TagWriterBufferFullException` when idle and when a write is in progress; a rejected write consumes no tag pid sequence nr; writes are accepted again once the buffer drains; nothing is rejected when the limit is `0`.
- `BufferSpec`: one case per `size` accounting bug.
- `sbt "core/testOnly ...BufferSpec ...TagWriterSpec ...TagWritersSpec"` — 48 passed. The existing `handle being overloaded` case doubles as a guard on the cost of the accounting fix: a fold over pending there made it quadratic and it did not complete.
- `sbt +mimaReportBinaryIssues` — no binary compatibility issues
- `sbt "+core/Test/compile"` — compiles on Scala 2.13.18 and 3.3.8
- `sbt docs/paradox` — builds
- `sbt scalafmtAll headerCreateAll` — clean
- Cassandra integration tests — Not run locally, no Cassandra instance or Docker available in this environment. They run in CI.

### References

Refs #478
