### PR TITLE
add metadata-page-size config

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -520,6 +520,12 @@ pekko.persistence.cassandra {
     # (if any are present). If all attempts fail the recovery will fail and
     # the persistent actor will be stopped.
     max-load-attempts = 3
+
+    # Maximum number of snapshot metadata rows to fetch per CQL query page
+    # when querying with a timestamp constraint (the slow path). This bounds
+    # memory usage by fetching results in pages rather than all at once.
+    # Lower values reduce memory pressure; higher values reduce round-trips.
+    metadata-page-size = 100
   }
   //#snapshot
 

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -75,6 +75,8 @@ import scala.util.{ Failure, Success }
     session.prepare(selectSnapshotMetadata(limit = None))
   private def preparedSelectSnapshotMetadataWithMaxLoadAttemptsLimit: Future[PreparedStatement] =
     session.prepare(selectSnapshotMetadata(limit = Some(snapshotSettings.maxLoadAttempts)))
+  private def preparedSelectSnapshotMetadataPaged: Future[PreparedStatement] =
+    session.prepare(selectSnapshotMetadata(limit = Some(snapshotSettings.metadataPageSize)))
 
   override def preStart(): Unit =
     // eager initialization, but not from constructor
@@ -94,6 +96,7 @@ import scala.util.{ Failure, Success }
       preparedSelectSnapshot
       preparedSelectSnapshotMetadata
       preparedSelectSnapshotMetadataWithMaxLoadAttemptsLimit
+      preparedSelectSnapshotMetadataPaged
       log.debug("Initialized")
 
     case DeleteAllSnapshots(persistenceId) =>
@@ -107,12 +110,13 @@ import scala.util.{ Failure, Success }
       criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
     log.debug("loadAsync [{}] [{}]", persistenceId, criteria)
     // The normal case is that timestamp is not specified (Long.MaxValue) in the criteria and then we can
-    // use a select stmt with LIMIT if maxLoadAttempts, otherwise the result is iterated and
-    // non-matching timestamps are discarded.
+    // use a select stmt with LIMIT of maxLoadAttempts. When a timestamp constraint is specified (the slow path),
+    // we use a paged query with metadataPageSize LIMIT to bound memory usage while still supporting
+    // client-side timestamp filtering via the driver's automatic page fetching.
     val snapshotMetaPs =
       if (criteria.maxTimestamp == Long.MaxValue)
         preparedSelectSnapshotMetadataWithMaxLoadAttemptsLimit
-      else preparedSelectSnapshotMetadata
+      else preparedSelectSnapshotMetadataPaged
 
     for {
       p <- snapshotMetaPs
@@ -212,7 +216,8 @@ import scala.util.{ Failure, Success }
         || settings.cosmosDb
         || 0L < criteria.minTimestamp
         || criteria.maxTimestamp < SnapshotSelectionCriteria.latest().maxTimestamp) {
-        preparedSelectSnapshotMetadata.flatMap { snapshotMetaPs =>
+        // Use paged query for the slow path to bound memory usage
+        preparedSelectSnapshotMetadataPaged.flatMap { snapshotMetaPs =>
           // this meta query gets slower than slower if snapshots are deleted without a criteria.minSequenceNr as
           // all previous tombstones are scanned in the meta data query
           metadata(snapshotMetaPs, persistenceId, criteria, limit = None).flatMap {
@@ -266,10 +271,10 @@ import scala.util.{ Failure, Success }
         SnapshotMetadata(row.getString("persistence_id"), row.getLong("sequence_nr"), row.getLong("timestamp")))
       .dropWhile(_.timestamp > criteria.maxTimestamp)
 
-    limit match {
-      case Some(n) => source.take(n.toLong).runWith(Sink.seq)
-      case None    => source.runWith(Sink.seq)
-    }
+    // Always bound the number of results to prevent unbounded memory usage.
+    // The driver's automatic page fetching handles pagination transparently.
+    val effectiveLimit = limit.getOrElse(snapshotSettings.metadataPageSize)
+    source.take(effectiveLimit.toLong).runWith(Sink.seq)
   }
 
   def preparedDeleteSnapshot: Future[PreparedStatement] =

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/snapshot/SnapshotSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/snapshot/SnapshotSettings.scala
@@ -47,4 +47,6 @@ import com.typesafe.config.Config
 
   val maxLoadAttempts: Int = snapshotConfig.getInt("max-load-attempts")
 
+  val metadataPageSize: Int = snapshotConfig.getInt("metadata-page-size")
+
 }

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraPluginSettingsSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraPluginSettingsSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 import scala.util.Random
 
 import pekko.persistence.cassandra.journal.JournalSettings
+import pekko.persistence.cassandra.snapshot.SnapshotSettings
 
 class CassandraPluginSettingsSpec
     extends TestKit(ActorSystem("CassandraPluginConfigSpec"))
@@ -146,6 +147,30 @@ class CassandraPluginSettingsSpec
 
       val config = new JournalSettings(system, configWithFalseTablesAutocreate)
       config.tablesAutoCreate must be(false)
+    }
+  }
+
+  "A CassandraSnapshotSettings" must {
+
+    "set the metadata page size from config" in {
+      val config = new SnapshotSettings(system, defaultConfig)
+      config.metadataPageSize must be(100)
+    }
+
+    "set the max load attempts from config" in {
+      val config = new SnapshotSettings(system, defaultConfig)
+      config.maxLoadAttempts must be(3)
+    }
+
+    "allow overriding metadata page size" in {
+      lazy val customConfig =
+        ConfigFactory
+          .parseString("""
+          |snapshot.metadata-page-size = 250
+        """.stripMargin)
+          .withFallback(defaultConfig)
+      val config = new SnapshotSettings(system, customConfig)
+      config.metadataPageSize must be(250)
     }
   }
 

--- a/docs/src/main/paradox/configuration.md
+++ b/docs/src/main/paradox/configuration.md
@@ -56,3 +56,33 @@ Alternatively, Pekko Discovery can be used for finding the Cassandra server cont
 in the @extref:[Pekko Connectors Cassandra documentation](pekko-connectors:cassandra.html#using-pekko-discovery).
 
 Without any configuration it will use `localhost:9042` as default.
+
+## Page size (fetch size)
+
+The DataStax driver's page size controls how many rows are fetched per CQL round-trip. This affects memory usage
+and network round-trips for queries that return multiple rows. The default is 5000 rows per page.
+
+These settings can be added directly to your application's `application.conf` file alongside your Pekko configuration.
+
+To configure the page size globally:
+
+```hocon
+datastax-java-driver.basic.request.page-size = 1000
+```
+
+Or per execution profile (the plugin uses `pekko-persistence-cassandra-profile` by default for all journal and snapshot queries):
+
+```hocon
+datastax-java-driver {
+  profiles {
+    pekko-persistence-cassandra-profile {
+      basic.request.page-size = 1000
+    }
+  }
+}
+```
+
+Lower values reduce memory usage per query; higher values reduce round-trips for large result sets.
+The driver automatically fetches subsequent pages as needed when consuming a `Source[Row, NotUsed]`.
+
+See the @extref:[DataStax driver documentation](java-driver:manual/core/configuration/) for more details.

--- a/docs/src/main/paradox/snapshots.md
+++ b/docs/src/main/paradox/snapshots.md
@@ -94,8 +94,20 @@ To activate the snapshot-store plugin, add the following line to your Pekko `app
     pekko.persistence.snapshot-store.plugin = "pekko.persistence.cassandra.snapshot"
 
 This will run the snapshot store with its default settings. The default settings can be changed with the configuration
-properties defined in @ref:[reference.conf](configuration.md#default-configuration). Journal configuration is under 
+properties defined in @ref:[reference.conf](configuration.md#default-configuration). Snapshot configuration is under 
 `pekko.persistence.cassandra.snapshot`.
+
+### Metadata page size
+
+When loading or deleting snapshots, the plugin queries the snapshot metadata table. For persistence IDs with many
+snapshots, this query can return a large number of rows. The `metadata-page-size` setting controls how many rows
+are fetched per CQL page, bounding memory usage.
+
+The default is 100 rows per page. The DataStax driver automatically fetches subsequent pages as needed.
+
+```hocon
+pekko.persistence.cassandra.snapshot.metadata-page-size = 200
+```
 
 ## Limitations
 


### PR DESCRIPTION
Problem: The snapshot metadata "slow path" (timestamp-constrained, Cassandra 2.x, CosmosDB) loaded ALL matching rows into memory via Sink.seq, which could cause memory pressure for persistence IDs with many snapshots.

Solution: Added pagination via a configurable page size that bounds memory usage while leveraging the driver's automatic page fetching.

Changes Made:

1. core/src/main/resources/reference.conf
  - Added metadata-page-size = 100 config under snapshot section
2. core/src/main/scala/.../snapshot/SnapshotSettings.scala
  - Added metadataPageSize: Int setting
3. core/src/main/scala/.../snapshot/CassandraSnapshotStore.scala
  - Added preparedSelectSnapshotMetadataPaged prepared statement with page-size LIMIT
  - Updated loadAsync to use paged statement for slow path
  - Updated deleteAsync to use paged statement for slow path
  - Modified metadata() to always use take() for bounded memory, even when limit = None
4. core/src/test/scala/.../CassandraPluginSettingsSpec.scala
  - Added3 new tests for snapshot settings (metadataPageSize, maxLoadAttempts, override)

Key Design Decisions:

- Always bounded: The metadata() method now always uses take(effectiveLimit) to prevent unbounded memory growth
- Driver handles pagination: CassandraSession.select returns a Source[Row, NotUsed] that automatically fetches more pages from Cassandra as needed
- CQL LIMIT per page: Each page is bounded by the metadataPageSize CQL LIMIT, so memory usage is proportional to page size, not total result set
- Configurable: Users can tune metadata-page-size based on their snapshot count and memory constraints