### PR TITLE
add circuit breaker for writes

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -179,6 +179,23 @@ pekko.persistence.cassandra {
     # that case the all_persistence_id table can be reconstructed with
     # Reconcilation.rebuildAllPersistenceIds.
     support-all-persistence-ids = on
+
+    # Circuit breaker for Cassandra writes. When enabled, the journal will stop
+    # attempting writes to Cassandra after a configurable number of consecutive
+    # failures, preventing cascading failures when Cassandra is unavailable.
+    # Set max-failures to 0 to disable the circuit breaker (the default).
+    circuit-breaker {
+      # Number of consecutive write failures before the circuit opens.
+      # Set to 0 to disable the circuit breaker.
+      max-failures = 0
+
+      # How long to wait after the circuit opens before allowing a test write.
+      reset-timeout = 30s
+
+      # Timeout for individual write calls through the circuit breaker.
+      # Should be long enough to cover normal Cassandra write latency.
+      call-timeout = 20s
+    }
   }
   //#journal
 

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournal.scala
@@ -23,7 +23,7 @@ import pekko.actor.SupervisorStrategy.Stop
 import pekko.actor._
 import pekko.annotation.{ DoNotInherit, InternalApi, InternalStableApi }
 import pekko.event.{ Logging, LoggingAdapter }
-import pekko.pattern.{ ask, pipe }
+import pekko.pattern.{ ask, pipe, CircuitBreaker }
 import pekko.persistence._
 import pekko.persistence.cassandra._
 import pekko.persistence.cassandra.Extractors
@@ -113,6 +113,21 @@ import scala.util.{ Failure, Success, Try }
 
   private val tagRecovery: Option[CassandraTagRecovery] =
     tagWrites.map(ref => new CassandraTagRecovery(context.system, session, settings, taggedPreparedStatements, ref))
+
+  private val writeCircuitBreaker: Option[CircuitBreaker] = {
+    val cbSettings = settings.journalSettings.circuitBreakerSettings
+    if (cbSettings.enabled) {
+      val cb = new CircuitBreaker(
+        context.system.scheduler,
+        maxFailures = cbSettings.maxFailures,
+        callTimeout = cbSettings.callTimeout,
+        resetTimeout = cbSettings.resetTimeout)(context.dispatcher)
+      cb.onOpen(log.warning("Cassandra write circuit breaker opened after {} failures", cbSettings.maxFailures))
+      cb.onHalfOpen(log.info("Cassandra write circuit breaker half-open, testing Cassandra availability"))
+      cb.onClose(log.info("Cassandra write circuit breaker closed, Cassandra writes resumed"))
+      Some(cb)
+    } else None
+  }
 
   private val preparedWriteMessage: RetryableFutureEval[PreparedStatement] =
     RetryableFutureEval(() => session.prepare(statements.journalStatements.writeMessage(withMeta = false)))
@@ -701,10 +716,13 @@ import scala.util.{ Failure, Success, Try }
   }
 
   private def executeBatch(body: BatchStatement => BatchStatement): Future[Unit] = {
-    var batch =
-      new BatchStatementBuilder(BatchType.UNLOGGED).build().setExecutionProfileName(journalSettings.writeProfile)
-    batch = body(batch)
-    session.underlying().flatMap(_.executeAsync(batch).asScala).map(_ => ())
+    val doExecute: Future[Unit] = {
+      var batch =
+        new BatchStatementBuilder(BatchType.UNLOGGED).build().setExecutionProfileName(journalSettings.writeProfile)
+      batch = body(batch)
+      session.underlying().flatMap(_.executeAsync(batch).asScala).map(_ => ())
+    }
+    writeCircuitBreaker.fold(doExecute)(_.withCircuitBreaker(doExecute))
   }
 
   private def selectOne[T <: Statement[T]](stmt: Statement[T]): Future[Option[Row]] = {
@@ -715,7 +733,9 @@ import scala.util.{ Failure, Success, Try }
     partitionNr * journalSettings.targetPartitionSize + 1
 
   private def execute[T <: Statement[T]](stmt: Statement[T]): Future[Unit] = {
-    session.executeWrite(stmt.setExecutionProfileName(journalSettings.writeProfile)).map(_ => ())
+    val doExecute: Future[Unit] =
+      session.executeWrite(stmt.setExecutionProfileName(journalSettings.writeProfile)).map(_ => ())
+    writeCircuitBreaker.fold(doExecute)(_.withCircuitBreaker(doExecute))
   }
 
   // TODO this serialises and re-serialises the messages for fixing tag_views

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/JournalSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/JournalSettings.scala
@@ -23,6 +23,8 @@ import pekko.persistence.cassandra.compaction.CassandraCompactionStrategy
 import pekko.persistence.cassandra.getListFromConfig
 import com.typesafe.config.Config
 
+import scala.concurrent.duration._
+
 /** INTERNAL API */
 @InternalStableApi
 @InternalApi private[pekko] class JournalSettings(system: ActorSystem, config: Config)
@@ -63,4 +65,20 @@ import com.typesafe.config.Config
 
   val coordinatedShutdownOnError: Boolean = config.getBoolean("coordinated-shutdown-on-error")
 
+  val circuitBreakerSettings: CircuitBreakerSettings = {
+    val cbConfig = journalConfig.getConfig("circuit-breaker")
+    CircuitBreakerSettings(
+      maxFailures = cbConfig.getInt("max-failures"),
+      resetTimeout = cbConfig.getDuration("reset-timeout").toMillis.millis,
+      callTimeout = cbConfig.getDuration("call-timeout").toMillis.millis)
+  }
+
+}
+
+/** INTERNAL API */
+@InternalApi private[pekko] final case class CircuitBreakerSettings(
+    maxFailures: Int,
+    resetTimeout: FiniteDuration,
+    callTimeout: FiniteDuration) {
+  val enabled: Boolean = maxFailures > 0
 }

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraPluginSettingsSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraPluginSettingsSpec.scala
@@ -147,6 +147,38 @@ class CassandraPluginSettingsSpec
       val config = new JournalSettings(system, configWithFalseTablesAutocreate)
       config.tablesAutoCreate must be(false)
     }
+
+    "have circuit breaker disabled by default" in {
+      val config = new JournalSettings(system, defaultConfig)
+      val cb = config.circuitBreakerSettings
+      cb.enabled must be(false)
+      cb.maxFailures must be(0)
+    }
+
+    "parse circuit breaker settings when enabled" in {
+      val configWithCircuitBreaker = ConfigFactory.parseString("""
+          |journal.circuit-breaker.max-failures = 5
+          |journal.circuit-breaker.reset-timeout = 60s
+          |journal.circuit-breaker.call-timeout = 15s
+        """.stripMargin).withFallback(defaultConfig)
+      val config = new JournalSettings(system, configWithCircuitBreaker)
+      val cb = config.circuitBreakerSettings
+      cb.enabled must be(true)
+      cb.maxFailures must be(5)
+      cb.resetTimeout must be(scala.concurrent.duration.DurationInt(60).seconds)
+      cb.callTimeout must be(scala.concurrent.duration.DurationInt(15).seconds)
+    }
+
+    "allow overriding circuit breaker max-failures" in {
+      val configWithCircuitBreaker = ConfigFactory.parseString("""
+          |journal.circuit-breaker.max-failures = 3
+        """.stripMargin).withFallback(defaultConfig)
+      val config = new JournalSettings(system, configWithCircuitBreaker)
+      val cb = config.circuitBreakerSettings
+      cb.enabled must be(true)
+      cb.maxFailures must be(3)
+      cb.resetTimeout must be(scala.concurrent.duration.DurationInt(30).seconds)
+    }
   }
 
 }

--- a/docs/src/main/paradox/journal.md
+++ b/docs/src/main/paradox/journal.md
@@ -209,6 +209,29 @@ datastax-java-driver.profiles {
 }
 ```
 
+### Circuit breaker
+
+When Cassandra becomes unavailable, each write attempt will wait for the full timeout before failing.
+This can cause cascading failures — thread pool exhaustion, growing queues, and delayed failure detection.
+
+The circuit breaker prevents this by failing fast when Cassandra is known to be unavailable:
+
+```hocon
+pekko.persistence.cassandra.journal.circuit-breaker {
+  max-failures = 10
+  reset-timeout = 30s
+  call-timeout = 20s
+}
+```
+
+- `max-failures`: Number of consecutive write failures before the circuit opens. Set to 0 to disable (the default).
+- `reset-timeout`: How long to wait after the circuit opens before allowing a test write.
+- `call-timeout`: Timeout for individual write calls through the circuit breaker.
+
+When the circuit is open, writes fail immediately with `CircuitBreakerOpenException` without attempting to contact Cassandra.
+After `reset-timeout`, the circuit enters a half-open state and allows a single test write. If it succeeds, the circuit closes
+and normal writes resume. If it fails, the circuit opens again.
+
 ## Event deletion and retention
 
 In applications with an Event Sourcing model of persistence, an idealized journal is _append-only_: events are never deleted.


### PR DESCRIPTION
The journal and tag writers lack circuit breakers. A circuit breaker would prevent cascading failures when Cassandra is unavailable.

Files modified:

1. core/src/main/resources/reference.conf — Added circuit-breaker section under journal with max-failures = 0 (disabled by default), reset-timeout = 30s, call-timeout = 20s
2. core/src/main/scala/.../journal/JournalSettings.scala — Added CircuitBreakerSettings case class and parsing from config
3. core/src/main/scala/.../journal/CassandraJournal.scala —
  - Added CircuitBreaker import
  - Created writeCircuitBreaker instance (only when max-failures > 0)
  - Added logging callbacks for open/half-open/close state transitions
  - Wrapped executeBatch and execute methods with withCircuitBreaker
4. core/src/test/scala/.../CassandraPluginSettingsSpec.scala — Added 3 tests for circuit breaker settings (disabled by default, enabled parsing, override)
5. docs/src/main/paradox/journal.md — Added "Circuit breaker" subsection under Configuration

Design decisions:
- Disabled by default (max-failures = 0) — backward compatible, users opt in
- Journal-level only — TagWriter has its own retry mechanism; if journal circuit is open, no events reach TagWriter anyway
- Uses Pekko's built-in CircuitBreaker — well-tested, handles the state machine (closed → open → half-open → closed)