### PR TITLE
Update pekkoVersion to 2.0.0-M4

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/TagWriter.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/TagWriter.scala
@@ -184,7 +184,7 @@ import scala.util.{ Failure, Success, Try }
       become(idle(buffer.remove(pid), tagPidSequenceNrs + (pid -> tagPidSequenceNr)))
       sender() ! ResetPersistenceIdComplete
 
-    case ReceiveTimeout =>
+    case _: ReceiveTimeout =>
       if (buffer.isEmpty && tagPidSequenceNrs.isEmpty)
         parent ! PassivateTagWriter(tag)
 
@@ -281,7 +281,7 @@ import scala.util.{ Failure, Success, Try }
       become(writeInProgress(buffer.remove(pid), tagPidSequenceNrs + (pid -> tp.pidTagSequenceNr), awaitingFlush))
       sender() ! ResetPersistenceIdComplete
 
-    case ReceiveTimeout =>
+    case _: ReceiveTimeout =>
     // not idle
 
     case StopTagWriter =>

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/sharding/ClusterShardingQuickTerminationSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/sharding/ClusterShardingQuickTerminationSpec.scala
@@ -53,11 +53,11 @@ object ClusterShardingQuickTerminationSpec {
     }
 
     override def receiveCommand: Receive = {
-      case Increment      => persist(CounterChanged(+1))(updateState)
-      case Decrement      => persist(CounterChanged(-1))(updateState)
-      case Get(_)         => sender() ! count
-      case ReceiveTimeout => context.parent ! Passivate(stopMessage = Stop)
-      case Stop           =>
+      case Increment         => persist(CounterChanged(+1))(updateState)
+      case Decrement         => persist(CounterChanged(-1))(updateState)
+      case Get(_)            => sender() ! count
+      case _: ReceiveTimeout => context.parent ! Passivate(stopMessage = Stop)
+      case Stop              =>
         sender() ! Ack
         context.stop(self)
     }

--- a/project/PekkoCoreDependency.scala
+++ b/project/PekkoCoreDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoCoreDependency extends PekkoDependency {
   override val checkProject: String = "pekko-cluster-sharding-typed"
   override val module: Option[String] = None
-  override val currentVersion: String = "2.0.0-M3"
+  override val currentVersion: String = "2.0.0-M4"
 }


### PR DESCRIPTION
https://github.com/apache/pekko/pull/3399 is the cause of this test issue:

```
[info] - must passivate when idle *** FAILED *** (3 seconds, 47 milliseconds)
[info]   java.lang.AssertionError: assertion failed: timeout (3 seconds) during expectMsg while waiting for PassivateTagWriter(tag-1)
[info]   at scala.runtime.Scala3RunTime$.assertFailed(Scala3RunTime.scala:8)
[info]   at org.apache.pekko.testkit.TestKitBase.expectMsg_internal(TestKit.scala:471)
[info]   at org.apache.pekko.testkit.TestKitBase.expectMsg(TestKit.scala:448)
[info]   at org.apache.pekko.testkit.TestKitBase.expectMsg$(TestKit.scala:168)
[info]   at org.apache.pekko.testkit.TestKit.expectMsg(TestKit.scala:964)
[info]   at org.apache.pekko.persistence.cassandra.journal.TagWriterSpec$$anon$24.<init>(TagWriterSpec.scala:646)
[info]   at org.apache.pekko.persistence.cassandra.journal.TagWriterSpec.f$proxy24$1(TagWriterSpec.scala:639)
[info]   at org.apache.pekko.persistence.cassandra.journal.TagWriterSpec.$init$$$anonfun$2$$anonfun$24(TagWriterSpec.scala:639)
[info]   at org.scalatest.Transformer.apply$$anonfun$1(Transformer.scala:22)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:31)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:22)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:21)
[info]   at org.scalatest.wordspec.AnyWordSpecLike$$anon$3.apply(AnyWordSpecLike.scala:1118)
[info]   at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
[info]   at org.scalatest.TestSuite.withFixture$(TestSuite.scala:138)
[info]   at org.apache.pekko.persistence.cassandra.journal.TagWriterSpec.withFixture(TagWriterSpec.scala:68)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.invokeWithFixture$1(AnyWordSpecLike.scala:1124)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTest$$anonfun$1(AnyWordSpecLike.scala:1128)
[info]   at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTest(AnyWordSpecLike.scala:1128)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTest$(AnyWordSpecLike.scala:44)
[info]   at org.apache.pekko.persistence.cassandra.journal.TagWriterSpec.org$scalatest$BeforeAndAfterEach$$super$runTest(TagWriterSpec.scala:68)
[info]   at org.scalatest.BeforeAndAfterEach.runTest(BeforeAndAfterEach.scala:234)
[info]   at org.scalatest.BeforeAndAfterEach.runTest$(BeforeAndAfterEach.scala:122)
[info]   at org.apache.pekko.persistence.cassandra.journal.TagWriterSpec.runTest(TagWriterSpec.scala:68)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTests$$anonfun$1(AnyWordSpecLike.scala:1187)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1$$anonfun$1(Engine.scala:413)
[info]   at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
[info]   at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
[info]   at scala.collection.immutable.List.foreach(List.scala:323)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:429)
[info]   at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:390)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1$$anonfun$1(Engine.scala:427)
[info]   at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
[info]   at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
[info]   at scala.collection.immutable.List.foreach(List.scala:323)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:429)
[info]   at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:396)
[info]   at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTests(AnyWordSpecLike.scala:1187)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTests$(AnyWordSpecLike.scala:44)
[info]   at org.apache.pekko.persistence.cassandra.journal.TagWriterSpec.runTests(TagWriterSpec.scala:68)
[info]   at org.scalatest.Suite.run(Suite.scala:1114)
[info]   at org.scalatest.Suite.run$(Suite.scala:564)
[info]   at org.apache.pekko.persistence.cassandra.journal.TagWriterSpec.org$scalatest$wordspec$AnyWordSpecLike$$super$run(TagWriterSpec.scala:68)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.run$$anonfun$1(AnyWordSpecLike.scala:1232)
[info]   at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.run(AnyWordSpecLike.scala:1232)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.run$(AnyWordSpecLike.scala:44)
[info]   at org.apache.pekko.persistence.cassandra.journal.TagWriterSpec.org$scalatest$BeforeAndAfterAll$$super$run(TagWriterSpec.scala:68)
[info]   at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
[info]   at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:217)
[info]   at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:135)
[info]   at org.apache.pekko.persistence.cassandra.journal.TagWriterSpec.run(TagWriterSpec.scala:68)
[info]   at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:321)
[info]   at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:517)
[info]   at sbt.ForkMain$Run.lambda$runTest$1(ForkMain.java:414)
[info]   at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[info]   at java.base/java.lang.Thread.run(Thread.java:840)
```