### PR TITLE
bound the reverse read when searching for the highest sequence nr

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournal.scala
@@ -122,8 +122,13 @@ import scala.util.{ Failure, Success, Try }
     else
       None
   }
+  // unbounded, used by the delete path which needs the highest sequence nr of a specific partition
   private val preparedSelectHighestSequenceNr: RetryableFutureEval[PreparedStatement] =
     RetryableFutureEval(() => session.prepare(statements.journalStatements.selectHighestSequenceNr))
+
+  // bounded, used when scanning partitions for the highest sequence nr of a persistenceId
+  private val preparedSelectHighestSequenceNrGreaterThan: RetryableFutureEval[PreparedStatement] =
+    RetryableFutureEval(() => session.prepare(statements.journalStatements.selectHighestSequenceNrGreaterThan))
 
   private val deletesNotSupportedException: RetryableFutureEval[PreparedStatement] =
     RetryableFutureEval(() =>
@@ -206,6 +211,7 @@ import scala.util.{ Failure, Success, Try }
       preparedWriteMessageWithMeta.futureResult()
       preparedSelectMessages.futureResult()
       preparedSelectHighestSequenceNr.futureResult()
+      preparedSelectHighestSequenceNrGreaterThan.futureResult()
       if (settings.journalSettings.supportAllPersistenceIds)
         preparedInsertIntoAllPersistenceIds.futureResult()
       if (settings.journalSettings.supportDeletes) {
@@ -673,10 +679,23 @@ import scala.util.{ Failure, Success, Try }
       persistenceId: String,
       fromSequenceNr: Long,
       partitionSize: Long): Future[Long] = {
-    def find(currentPnr: Long, currentSnr: Long, foundEmptyPartition: Boolean): Future[Long] = {
+    // Every statement of an AtomicWrite is stored in the partition of its *last* sequence number and an
+    // AtomicWrite may span at most two partitions, so partition numbers increase monotonically with
+    // sequence number: every row of a later partition is above every row of an earlier one. That makes
+    // `sequence_nr > currentSnr` a filter that can never hide the answer, only rows already known to be
+    // below it.
+    //
+    // The trade-off is that a partition holding nothing above `currentSnr` is indistinguishable from an
+    // empty one, so the scan cannot stop at the first such partition. Two of them can precede the first
+    // row that matters: the partition the floor itself lives in, plus one that an AtomicWrite skipped
+    // over. Probing three consecutive partitions before giving up covers both, and costs one extra
+    // bounded query per scan compared with an unbounded reverse read per partition.
+    val maxConsecutiveEmptyPartitions = 3
+
+    def find(currentPnr: Long, currentSnr: Long, consecutiveEmptyPartitions: Int): Future[Long] = {
       // if every message has been deleted and thus no sequence_nr the driver gives us back 0 for "null" :(
-      val boundSelectHighestSequenceNr = preparedSelectHighestSequenceNr.futureResult().map(ps => {
-        val bound = ps.bind(persistenceId, currentPnr: JLong)
+      val boundSelectHighestSequenceNr = preparedSelectHighestSequenceNrGreaterThan.futureResult().map(ps => {
+        val bound = ps.bind(persistenceId, currentPnr: JLong, currentSnr: JLong)
         bound
 
       })
@@ -687,17 +706,17 @@ import scala.util.{ Failure, Success, Try }
         }
         .flatMap {
           case None | Some(0) =>
-            // never been to this partition, query one more partition because AtomicWrite can span (skip)
-            // one entire partition
+            // nothing above currentSnr here, but a later partition may still hold events
             // Some(0) when old schema with static used column, everything deleted in this partition
-            if (foundEmptyPartition) Future.successful(currentSnr)
-            else find(currentPnr + 1, currentSnr, foundEmptyPartition = true)
+            val emptyPartitions = consecutiveEmptyPartitions + 1
+            if (emptyPartitions >= maxConsecutiveEmptyPartitions) Future.successful(currentSnr)
+            else find(currentPnr + 1, currentSnr, emptyPartitions)
           case Some(nextHighest) =>
-            find(currentPnr + 1, nextHighest, foundEmptyPartition = false)
+            find(currentPnr + 1, nextHighest, consecutiveEmptyPartitions = 0)
         }
     }
 
-    find(partitionNr(fromSequenceNr, partitionSize), fromSequenceNr, foundEmptyPartition = false)
+    find(partitionNr(fromSequenceNr, partitionSize), fromSequenceNr, consecutiveEmptyPartitions = 0)
   }
 
   private def executeBatch(body: BatchStatement => BatchStatement): Future[Unit] = {

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournalStatements.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournalStatements.scala
@@ -295,6 +295,24 @@ import scala.jdk.FutureConverters._
        DESC LIMIT 1
    """
 
+  /**
+   * Same as `selectHighestSequenceNr` but restricted to sequence numbers above a known floor.
+   *
+   * `messages` is clustered by `sequence_nr` ascending, so a `DESC` query is a reverse read. Bounding
+   * the clustering slice keeps the reverse read off the part of the partition that is already known to
+   * be below the answer, which matters because Cassandra reverse reads are considerably more expensive
+   * than forward reads over large partitions.
+   */
+  def selectHighestSequenceNrGreaterThan =
+    s"""
+     SELECT sequence_nr FROM $tableName WHERE
+       persistence_id = ? AND
+       partition_nr = ? AND
+       sequence_nr > ?
+       ORDER BY sequence_nr
+       DESC LIMIT 1
+   """
+
   def selectDeletedTo =
     s"""
       SELECT deleted_to FROM $metadataTableName WHERE

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/CassandraHighestSequenceNrSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/CassandraHighestSequenceNrSpec.scala
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.persistence.cassandra.journal
+
+import org.apache.pekko
+import pekko.actor.{ ActorRef, PoisonPill, Props }
+import pekko.persistence.{ PersistentActor, RecoveryCompleted, SaveSnapshotSuccess, SnapshotOffer }
+import pekko.persistence.cassandra.CassandraSpec
+import pekko.testkit.TestProbe
+
+import scala.collection.immutable
+
+object CassandraHighestSequenceNrSpec {
+  case class PersistMe(msg: Long)
+  case class PersistAllMe(msgs: immutable.Seq[Long])
+  case object SnapshotMe
+  case object GetRecoveredEvents
+  case class Ack(sequenceNr: Long)
+  case class RecoveredEvents(events: Seq[Any])
+
+  class PA(val persistenceId: String, snapshotProbe: ActorRef) extends PersistentActor {
+
+    override def journalPluginId: String = "cassandra-plugin-small-partition-size.journal"
+
+    private var recoveredEvents: List[Any] = List.empty
+
+    override def receiveRecover: Receive = {
+      case _: SnapshotOffer => // the snapshot carries no state, it only moves the recovery start point
+      case event            => recoveredEvents = event :: recoveredEvents
+    }
+
+    override def receiveCommand: Receive = {
+      case p: PersistMe =>
+        val replyTo = sender()
+        persist(p) { _ =>
+          replyTo ! Ack(lastSequenceNr)
+        }
+      case PersistAllMe(msgs) =>
+        val replyTo = sender()
+        var remaining = msgs.size
+        persistAll(msgs.map(PersistMe(_))) { _ =>
+          remaining -= 1
+          if (remaining == 0) replyTo ! Ack(lastSequenceNr)
+        }
+      case SnapshotMe =>
+        saveSnapshot("snap")
+      case s: SaveSnapshotSuccess =>
+        snapshotProbe ! s
+      case GetRecoveredEvents =>
+        sender() ! RecoveredEvents(recoveredEvents.reverse)
+    }
+  }
+}
+
+class CassandraHighestSequenceNrSpec extends CassandraSpec(s"""
+    cassandra-plugin-small-partition-size = $${pekko.persistence.cassandra}
+    cassandra-plugin-small-partition-size {
+      journal.target-partition-size = 3
+      journal.keyspace = "HighestSequenceNrSpec"
+    }
+  """) {
+
+  import CassandraHighestSequenceNrSpec._
+
+  override def keyspaces(): Set[String] = super.keyspaces().union(Set("HighestSequenceNrSpec"))
+
+  "Highest sequence nr recovery" must {
+
+    // An AtomicWrite is stored entirely in the partition of its *last* sequence nr, so a write that
+    // crosses a boundary leaves the partition it started in empty. With a snapshot the search for the
+    // highest sequence nr starts from the partition holding the snapshot, which is followed by that
+    // empty partition. Stopping at either of them would hand back a sequence nr that is already in use.
+    "look past an empty partition left by an AtomicWrite that crossed a boundary" in {
+      val snapshots = TestProbe()
+      val pid = nextId()
+      val props = Props(new PA(pid, snapshots.ref))
+      val p1 = system.actorOf(props)
+
+      // target-partition-size is 3, so events 1-3 fill partition 0
+      (1L to 3L).foreach { i =>
+        p1 ! PersistMe(i)
+        expectMsg(Ack(i))
+      }
+
+      // the recovery start point is now in partition 0
+      p1 ! SnapshotMe
+      snapshots.expectMsgType[SaveSnapshotSuccess]
+
+      // events 4-7 are a single AtomicWrite spanning partitions 1 and 2, so all four rows are written
+      // to partition 2 and partition 1 is left with no rows at all
+      p1 ! PersistAllMe(4L to 7L)
+      expectMsg(Ack(7))
+
+      p1 ! PoisonPill
+
+      val p1TakeTwo = system.actorOf(props)
+      p1TakeTwo ! GetRecoveredEvents
+      expectMsg(
+        RecoveredEvents(List(PersistMe(4), PersistMe(5), PersistMe(6), PersistMe(7), RecoveryCompleted)))
+
+      // must continue after 7 rather than reuse a sequence nr already stored in partition 2
+      p1TakeTwo ! PersistMe(8)
+      expectMsg(Ack(8))
+    }
+
+    "find the highest sequence nr across many partitions without a snapshot" in {
+      val snapshots = TestProbe()
+      val pid = nextId()
+      val props = Props(new PA(pid, snapshots.ref))
+      val p1 = system.actorOf(props)
+
+      (1L to 20L).foreach { i =>
+        p1 ! PersistMe(i)
+        expectMsg(Ack(i))
+      }
+
+      p1 ! PoisonPill
+
+      val p1TakeTwo = system.actorOf(props)
+      p1TakeTwo ! PersistMe(21)
+      expectMsg(Ack(21))
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

Recovery finds the highest sequence nr by walking partitions and running this on each one:

```sql
SELECT sequence_nr FROM messages
WHERE persistence_id = ? AND partition_nr = ?
ORDER BY sequence_nr DESC LIMIT 1
```

`messages` is clustered by `sequence_nr` ascending, so this is a **reverse read**. Cassandra reverse reads over a large partition are considerably more expensive than forward reads, and `target-partition-size` defaults to 500000. That is what makes a mass actor restart show up as a wave of slow queries, as reported in #240.

The query asks for the highest sequence nr in the partition, but the caller only ever cares about sequence numbers above a floor it already knows — the snapshot sequence nr, `deleted_to`, or the highest sequence nr found in an earlier partition. Everything below that floor is read and then discarded.

For contrast, the snapshot table is created `WITH CLUSTERING ORDER BY (sequence_nr DESC)` so that its `DESC` queries are forward reads. The journal table cannot do the same, because replay needs ascending order.

### Modification

- Add `selectHighestSequenceNrGreaterThan`: the same query with an `AND sequence_nr > ?` restriction. `asyncFindHighestSequenceNr` uses it for the partition scan, binding the highest sequence nr known so far.

  This cannot hide the answer. Every statement of an `AtomicWrite` is stored in the partition of its *last* sequence nr, and `require(maxPnr - minPnr <= 1)` caps a write at two partitions, so partition numbers increase monotonically with sequence nr: every row of a later partition is above every row of an earlier one.

- Keep the unbounded `selectHighestSequenceNr` and its prepared statement. It has two other consumers that must not change:
  - `partitionInfo` on the delete path needs the highest sequence nr of one specific partition and binds only two parameters;
  - the read journal's gap check relies on the unbounded form returning a row on old schemas carrying the static `used` column, where a clustering restriction would return nothing instead.

- Replace the `foundEmptyPartition` flag with a counter and probe three consecutive partitions before giving up.

  With the restriction in place, a partition holding nothing above the floor is indistinguishable from an empty one, and two such partitions can precede the first row that matters: the partition the floor lives in, plus one that an `AtomicWrite` skipped over. The previous two-partition budget stops early in that case and returns a sequence nr that is already in use. With `target-partition-size = 3`: events 1-3 occupy partition 0; a `persistAll` of 4-7 has `maxPnr = partitionNr(7) = 2` so all four rows go to partition 2 and partition 1 is left empty; recovering from a snapshot at 3 then sees a miss in partition 0 and a miss in partition 1, and would answer 3.

### Result

The reverse read is restricted to the part of the partition that can still change the answer. Whenever recovery starts from a snapshot or from `deleted_to`, that slice holds only the events written since it, rather than the whole partition.

This narrows #240 rather than closing it. A cold recovery of a persistence id with no snapshot and nothing deleted has a floor of 0, so its first partition is still read unbounded. The cost is one extra bounded query at the end of each scan.

No schema change, no migration, no change to the write path, and no change in the answer returned for any existing journal.

### Tests

- Added `CassandraHighestSequenceNrSpec`, covering an `AtomicWrite` that crosses a partition boundary and leaves the partition it started in empty, with a snapshot placing the floor in an earlier partition. It fails against a two-partition probe budget and passes with three.
- `sbt +mimaReportBinaryIssues` — no binary compatibility issues
- `sbt "+core/Test/compile"` — compiles on Scala 2.13.18 and 3.3.8
- `sbt scalafmtAll headerCreateAll` — clean, no further changes
- Cassandra integration tests — **Not run locally**, no Cassandra instance or Docker available in this environment. The new spec and the existing deletion, journal and query specs run in CI. `CassandraJournalDeletionSpec` already exercises 100 events over size-3 partitions with deletes and recovery, which is the closest existing regression guard for this code path.

The performance claim rests on Cassandra's reverse-read behaviour and has not been benchmarked here. Confirmation from the reporter on a cluster showing the original symptom would be worth having before treating #240 as resolved.

### References

Refs #240
