### PR TITLE
document the Cassandra driver page size

### DIFF
--- a/docs/src/main/paradox/configuration.md
+++ b/docs/src/main/paradox/configuration.md
@@ -37,6 +37,38 @@ If the ip addresses of your cassandra nodes might change (e.g. if you use k8s) t
 should also be set (resolves a dns address again when new connections are created). This also implies disabling java's dns cache with `-Dnetworkaddress.cache.ttl=0`. 
 
 
+### Page size
+
+The page size controls how many rows the driver retrieves per network round-trip. Queries that can return many
+rows are fetched a page at a time, and the driver requests the next page automatically as the results are
+consumed, so this is a matter of how the reads are chunked rather than how many rows an operation returns.
+
+The driver default is 5000 rows. To change it for every query:
+
+```
+datastax-java-driver.basic.request.page-size = 1000
+```
+
+The plugin issues its queries under two execution profiles, so the page size can also be set for one of them on
+its own. The journal and query parts use `pekko-persistence-cassandra-profile`, the snapshot store uses
+`pekko-persistence-cassandra-snapshot-profile`:
+
+```
+datastax-java-driver.profiles {
+  pekko-persistence-cassandra-profile {
+    basic.request.page-size = 1000
+  }
+  pekko-persistence-cassandra-snapshot-profile {
+    basic.request.page-size = 100
+  }
+}
+```
+
+A smaller page size lowers the number of rows held per round-trip and the amount of work in a single Cassandra
+read; a larger one reduces the number of round-trips needed to read a large result set. It bounds the rows in
+flight, not the total an operation retains, so it does not by itself cap the memory used by a query whose whole
+result is collected before it is acted on.
+
 ### Cassandra driver overrides
 
 @@snip [reference.conf](/core/src/main/resources/reference.conf) { #profile }


### PR DESCRIPTION
### Motivation

The Cassandra driver's page size is the setting that controls how many rows a query retrieves per network round-trip, and it is the correct lever for tuning reads that can return many rows. It was not mentioned anywhere in the documentation.

That gap makes it easy to reach for a CQL `LIMIT` instead, which is a different thing entirely: `LIMIT` caps the total number of rows a query returns, so it truncates a result set rather than paging through it. #479 attempted exactly that substitution — this PR documents the real mechanism instead and carries none of its code.

### Modification

Adds a "Page size" subsection under "Cassandra driver configuration" in `docs/src/main/paradox/configuration.md`:

- what the setting does, and that the driver requests subsequent pages automatically as results are consumed;
- the driver default of 5000 rows (verified against `java-driver-core` 4.19.0's `reference.conf`);
- how to set it globally, and how to set it per execution profile.

The plugin uses **two** profiles, and both are named: `pekko-persistence-cassandra-profile` for the journal and query parts, and `pekko-persistence-cassandra-snapshot-profile` for the snapshot store.

The section also says what the setting does not do — it bounds the rows in flight per round-trip, not the total an operation retains, so it does not by itself cap the memory of a query whose whole result is collected before it is acted on.

Docs-only. No source, configuration or behaviour changes.

### Result

The page size is discoverable from the configuration documentation, with the correct profile names and without overstating what it bounds.

### Tests

- Not run - docs only
- `sbt docs/paradox` — builds cleanly; the new section renders and the existing `java-driver` extref links on the page still resolve

### References

None - documents an existing Cassandra driver setting. Supersedes the documentation part of #479.
