### PR TITLE
Add Cleanup.close to release the reconciliation it starts

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/cleanup/Cleanup.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/cleanup/Cleanup.scala
@@ -49,6 +49,9 @@ import com.datastax.oss.driver.api.core.cql.Row
  * When a list of `persistenceIds` are given they are deleted sequentially in the order
  * of the list. It's possible to parallelize the deletes by running several cleanup operations
  * at the same time operating on different sets of `persistenceIds`.
+ *
+ * The tagged event operations start an actor that lives until [[Cleanup#close]] is called, so an
+ * instance should be closed once the cleanup operations it was created for have completed.
  */
 @ApiMayChange
 final class Cleanup(systemProvider: ClassicActorSystemProvider, settings: CleanupSettings) {
@@ -68,9 +71,16 @@ final class Cleanup(systemProvider: ClassicActorSystemProvider, settings: Cleanu
   // operations on journal, snapshotStore and tagViews should be only be done when dry-run = false
   private val journal: ActorRef = Persistence(system).journalFor(pluginLocation + ".journal")
   private lazy val snapshotStore: ActorRef = Persistence(system).snapshotStoreFor(pluginLocation + ".snapshot")
-  private lazy val tagViewsReconciliation = new Reconciliation(
-    system,
-    new ReconciliationSettings(system.settings.config.getConfig(pluginLocation + ".reconciler")))
+  // only the tagged event operations need this and it starts an actor, so track whether it was
+  // created to keep `close` from creating one just to stop it again
+  @volatile private var tagViewsReconciliationCreated = false
+  private lazy val tagViewsReconciliation = {
+    val reconciliation = new Reconciliation(
+      system,
+      new ReconciliationSettings(system.settings.config.getConfig(pluginLocation + ".reconciler")))
+    tagViewsReconciliationCreated = true
+    reconciliation
+  }
 
   private implicit val askTimeout: Timeout = operationTimeout
 
@@ -339,6 +349,20 @@ final class Cleanup(systemProvider: ClassicActorSystemProvider, settings: Cleanu
   def deleteAllSnapshots(persistenceId: String): Future[Done] = {
     sendToSnapshotStore(CassandraSnapshotStore.DeleteAllSnapshots(persistenceId))
   }
+
+  /**
+   * Releases the resources that the tagged event operations acquired. Without this the actor that
+   * they start stays alive for the lifetime of the `ActorSystem`, so call this once the cleanup
+   * operations have completed.
+   *
+   * Any operation still in progress is aborted, so only close after the futures returned by the
+   * other methods have completed. This instance must not be used again after it has been closed.
+   *
+   * Calling this more than once has no further effect, and it does nothing if no tagged event
+   * operation was used.
+   */
+  def close(): Unit =
+    if (tagViewsReconciliationCreated) tagViewsReconciliation.close()
 
   private def foreach(
       persistenceIds: immutable.Seq[String],

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/reconciler/Reconciliation.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/reconciler/Reconciliation.scala
@@ -142,6 +142,9 @@ final private[pekko] class ReconciliationSession(session: CassandraSession, stat
  * To support running in the same system as a journal the tag writers actor would need to be shared
  * and all the interleavings of the actor running at the same be considered.
  *
+ * Each instance starts a tag writers actor that lives until [[Reconciliation#close]] is called, so
+ * an instance should be closed once the reconciliation operations it was created for have completed.
+ *
  * API likely to change when a java/scaladsl is added.
  */
 @ApiMayChange
@@ -213,4 +216,16 @@ final class Reconciliation(systemProvider: ClassicActorSystemProvider, settings:
 
   def rebuildAllPersistenceIds(): Future[Done] =
     queries.currentPersistenceIdsFromMessages().runWith(recSession.insertIntoPersistenceIds())
+
+  /**
+   * Stops the tag writers actor that this instance started. Without this the actor stays alive for
+   * the lifetime of the `ActorSystem`, so call it once the reconciliation operations have completed.
+   *
+   * Any operation still in progress is aborted, so only close after the futures returned by the other
+   * methods have completed. This instance must not be used again after it has been closed.
+   *
+   * Calling this more than once has no further effect.
+   */
+  def close(): Unit =
+    system.stop(tagWriters)
 }

--- a/core/src/test/scala/doc/reconciler/AllPersistenceIdsMigrationCompileOnly.scala
+++ b/core/src/test/scala/doc/reconciler/AllPersistenceIdsMigrationCompileOnly.scala
@@ -37,9 +37,11 @@ class AllPersistenceIdsMigrationCompileOnly {
   result.onComplete {
     case Success(_) =>
       system.log.info("All persistenceIds migrated.")
+      rec.close()
       system.terminate()
     case Failure(e) =>
       system.log.error(e, "All persistenceIds migration failed.")
+      rec.close()
       system.terminate()
   }
   // #migrate

--- a/core/src/test/scala/doc/reconciler/ReconciliationCompileOnly.scala
+++ b/core/src/test/scala/doc/reconciler/ReconciliationCompileOnly.scala
@@ -34,7 +34,7 @@ class ReconciliationCompileOnly {
 
   // Drop and re-create data for a persistence id
   val pid = "pid1"
-  for {
+  val result: Future[Done] = for {
     // do this before dropping the data
     tags <- rec.tagsForPersistenceId(pid)
     // drop the tag view for every tag for this persistence id
@@ -42,5 +42,8 @@ class ReconciliationCompileOnly {
     // optional: re-build, if this is ommited then it will be re-build next time the pid is started
     _ <- rec.rebuildTagViewForPersistenceIds(pid)
   } yield Done
+
+  // release the tag writers actor that the Reconciliation started
+  result.onComplete(_ => rec.close())
   // #reconcile
 }

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/cleanup/CleanupCloseSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/cleanup/CleanupCloseSpec.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.persistence.cassandra.cleanup
+
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+import org.apache.pekko
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import pekko.actor.{ ActorIdentity, ActorRef, ActorSystem, Identify }
+import pekko.testkit.{ ImplicitSender, TestKit }
+
+object CleanupCloseSpec {
+
+  // no Cassandra is needed, only the lifecycle of the reconciliation actor is asserted on
+  val config = ConfigFactory.parseString("""
+      pekko.persistence.cassandra.cleanup.dry-run = true
+      datastax-java-driver.advanced.reconnect-on-init = false
+    """)
+}
+
+class CleanupCloseSpec
+    extends TestKit(ActorSystem("CleanupCloseSpec", CleanupCloseSpec.config))
+    with AnyWordSpecLike
+    with Matchers
+    with ImplicitSender
+    with BeforeAndAfterAll {
+
+  override protected def afterAll(): Unit = {
+    shutdown()
+    super.afterAll()
+  }
+
+  private def reconciliationTagWriters(): Seq[ActorRef] = {
+    system.actorSelection("/system/reconciliation-tag-writers-*") ! Identify(())
+    receiveWhile(500.millis) {
+      case ActorIdentity(_, ref) => ref
+    }.flatten
+  }
+
+  "Cleanup" should {
+
+    "not start a reconciliation when only snapshot and event operations are used" in {
+      val cleanup = new Cleanup(system)
+
+      cleanup.close()
+
+      reconciliationTagWriters() shouldBe empty
+    }
+
+    "stop the reconciliation it started when closed" in {
+      val cleanup = new Cleanup(system)
+      // the returned future needs Cassandra and is deliberately not awaited, it is only used to
+      // trigger the creation of the internal Reconciliation
+      cleanup.deleteAllTaggedEvents("pid-1")
+
+      val tagWriters = reconciliationTagWriters()
+      tagWriters should have size 1
+      watch(tagWriters.head)
+
+      cleanup.close()
+
+      expectTerminated(tagWriters.head)
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/reconciler/ReconciliationCloseSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/reconciler/ReconciliationCloseSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.persistence.cassandra.reconciler
+
+import com.typesafe.config.ConfigFactory
+import org.apache.pekko
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import pekko.actor.{ ActorIdentity, ActorSystem, Identify }
+import pekko.testkit.{ ImplicitSender, TestKit }
+
+object ReconciliationCloseSpec {
+
+  // no Cassandra is needed, the tag writers actor is started eagerly and all queries are lazy
+  val config = ConfigFactory.parseString("""
+      datastax-java-driver.advanced.reconnect-on-init = false
+    """)
+}
+
+class ReconciliationCloseSpec
+    extends TestKit(ActorSystem("ReconciliationCloseSpec", ReconciliationCloseSpec.config))
+    with AnyWordSpecLike
+    with Matchers
+    with ImplicitSender
+    with BeforeAndAfterAll {
+
+  override protected def afterAll(): Unit = {
+    shutdown()
+    super.afterAll()
+  }
+
+  "Reconciliation" should {
+
+    "stop its tag writers actor when closed, and tolerate a second close" in {
+      val reconciliation = new Reconciliation(system)
+
+      // resolve while this is the only actor in the system matching the pattern: an actor that
+      // has been stopped can still be in the guardian's children when its watchers have already
+      // seen Terminated, and the Identify sent to it is answered from dead letters with an empty
+      // ActorIdentity, which would race with the one from the live actor
+      system.actorSelection("/system/reconciliation-tag-writers-*") ! Identify(())
+      val tagWriters = watch(expectMsgType[ActorIdentity].ref.get)
+
+      reconciliation.close()
+      expectTerminated(tagWriters)
+
+      // a second close has no further effect
+      reconciliation.close()
+    }
+  }
+}

--- a/docs/src/main/paradox/cleanup.md
+++ b/docs/src/main/paradox/cleanup.md
@@ -28,4 +28,7 @@ Scala
 Java
 : @@snip [snapshot-keyspace](/docs/src/test/java/jdoc/cleanup/CleanupDocExample.java) { #cleanup } 
 
+The operations that delete tagged events start an actor that lives for as long as the `ActorSystem` does, so call
+`close()` on the cleanup tool once the operations have completed.
+
 By default, all operations only print what they were going to do. Once you're happy with what the cleanup tool is going to do set `pekko.persistence.cassandra.cleanup.dry-run = false`

--- a/docs/src/main/paradox/events-by-tag.md
+++ b/docs/src/main/paradox/events-by-tag.md
@@ -153,6 +153,9 @@ It supports:
 
 After deleting the tag views they will be automatically re-built next time the persistence id starts or with an explicit rebuild.
 
+Each `Reconciliation` instance starts a tag writers actor that lives for as long as the `ActorSystem` does, so call `close()`
+once the reconciliation operations have completed.
+
 For example, to rebuild the data for a persistence id:
 
 @@snip [reconciler](/core/src/test/scala/doc/reconciler/ReconciliationCompileOnly.scala) { #imports #reconcile}                                                                                                                                


### PR DESCRIPTION
> **Stacked on #492** — it needs `Reconciliation.close()`, so this PR's diff currently includes that commit. It will reduce to the `Cleanup` commit alone once #492 is merged.

### Motivation

`Cleanup`'s tagged event operations lazily create a `Reconciliation`, which starts a system actor that stays alive for the lifetime of the `ActorSystem`. `Cleanup` is documented as a per-batch tool that can be run several times in parallel ("It's possible to parallelize the deletes by running several cleanup operations at the same time"), so every instance that deletes tagged events leaks one of those actors.

### Modification

- Add `Cleanup.close()`, which closes the internal `Reconciliation`.
- Track whether the lazily created `Reconciliation` exists, so that closing a `Cleanup` that never touched tagged events does not create one just to stop it again.
- Document the new method on the class and in the cleanup docs.

### Result

Callers can release the actor when they are done cleaning up, and a `Cleanup` used only for snapshot or event deletes never starts one at all. `close()` is idempotent.

### Tests

- `sbt "core/Test/testOnly org.apache.pekko.persistence.cassandra.cleanup.CleanupCloseSpec"` — passed. New spec, asserts that no reconciliation actor is started when only snapshot/event operations are used, and that the one started by a tagged event operation terminates on `close()`. Needs no Cassandra.
- `sbt "core/mimaReportBinaryIssues"` — passed.
- `scalafmt --mode diff-ref=upstream/main --list` — no changes needed.
- `git diff --check` — clean.
- Cassandra integration tests not run — no local Cassandra (docker not running).

### References

Refs #492 - resource leak found while auditing actor and session lifecycles.
