### PR TITLE
Terminate the ActorSystems that specs leave running

### DIFF
--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/EventsByTagMigrationSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/EventsByTagMigrationSpec.scala
@@ -427,6 +427,7 @@ abstract class AbstractEventsByTagMigrationSpec
         e.printStackTrace()
     }
     super.afterAll()
+    shutdown(migrationSystem)
     shutdown(systemTwo)
     shutdown(systemThree)
   }

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/ReconnectSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/ReconnectSpec.scala
@@ -18,6 +18,7 @@ import pekko.actor.{ ActorSystem, Props }
 import pekko.persistence.cassandra.CassandraLifecycle.AwaitPersistenceInit
 import pekko.testkit.{ ImplicitSender, SocketUtil, TestKit }
 import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Suite
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
@@ -43,7 +44,14 @@ class ReconnectSpec
     with ImplicitSender
     with AnyWordSpecLike
     with Matchers
-    with ScalaFutures {
+    with ScalaFutures
+    with BeforeAndAfterAll {
+
+  override protected def afterAll(): Unit = {
+    // not verifying the shutdown, the driver is left reconnecting to a Cassandra that is gone
+    shutdown(system)
+    super.afterAll()
+  }
 
   "Reconnecting" must {
     "start with system off" in {

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/PubSubThrottlerSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/PubSubThrottlerSpec.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.persistence.cassandra.journal
 
 import scala.concurrent.duration.DurationInt
 
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
 
@@ -25,7 +26,14 @@ import pekko.testkit.{ TestKit, TestProbe }
 class PubSubThrottlerSpec
     extends TestKit(ActorSystem("CassandraConfigCheckerSpec"))
     with AnyWordSpecLike
-    with Matchers {
+    with Matchers
+    with BeforeAndAfterAll {
+
+  override protected def afterAll(): Unit = {
+    shutdown(system, verifySystemShutdown = true)
+    super.afterAll()
+  }
+
   "PubSubThrottler" should {
     "eat up duplicate messages that arrive within the same [interval] window" in {
       val delegate = TestProbe()


### PR DESCRIPTION
### Motivation

Three specs create an `ActorSystem` that is never terminated, so it lives for the rest of the test JVM run:

- `PubSubThrottlerSpec` — no `afterAll` at all.
- `ReconnectSpec` — no `afterAll` at all, and the worse of the two: its driver is configured with `advanced.reconnect-on-init = true` against a port whose Cassandra container is stopped at the end of the test, so its reconnection threads carry on afterwards.
- `AbstractEventsByTagMigrationSpec` — shuts down `systemTwo` and `systemThree` but not `migrationSystem`.

### Modification

Shut the `ActorSystem` down in `afterAll` in all three specs. `PubSubThrottlerSpec` uses `verifySystemShutdown = true`; `ReconnectSpec` deliberately does not, since its driver is left reconnecting to a Cassandra that has been stopped and verifying would risk a flake.

### Result

The suites release their `ActorSystem`s instead of leaving them running for the rest of the test JVM.

### Tests

- `sbt "core/Test/testOnly org.apache.pekko.persistence.cassandra.journal.PubSubThrottlerSpec"` — passed, including the verified shutdown.
- `sbt "core/Test/compile"` — passed.
- `scalafmt --mode diff-ref=upstream/main --list` — no changes needed.
- `git diff --check` — clean.
- `ReconnectSpec` and `EventsByTagMigrationSpec` not run — they need Cassandra/docker, not available locally.

### References

None - resource leak found while auditing actor and session lifecycles.
