### PR TITLE
chore: remove leftover Scala 2.12 idioms

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/KeyspaceAndTableStatements.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/KeyspaceAndTableStatements.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.persistence.cassandra
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.actor.ClassicActorSystemProvider
 
@@ -42,7 +40,7 @@ class KeyspaceAndTableStatements(
    * This can be queried in for example a startup script without accessing the actual
    * Cassandra plugin actor.
    */
-  def createJournalTablesStatements: immutable.Seq[String] =
+  def createJournalTablesStatements: Seq[String] =
     journalStatements.createTable ::
     journalStatements.createTagsTable ::
     journalStatements.createTagsProgressTable ::
@@ -77,7 +75,7 @@ class KeyspaceAndTableStatements(
    * This can be queried in for example a startup script without accessing the actual
    * Cassandra plugin actor.
    */
-  def createSnapshotTablesStatements: immutable.Seq[String] =
+  def createSnapshotTablesStatements: Seq[String] =
     snapshotStatements.createTable :: Nil
 
   /**

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/cleanup/Cleanup.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/cleanup/Cleanup.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.persistence.cassandra.cleanup
 
 import java.lang.{ Integer => JInt, Long => JLong }
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.Failure
 import scala.util.Success
@@ -182,7 +181,7 @@ final class Cleanup(systemProvider: ClassicActorSystemProvider, settings: Cleanu
    */
   def deleteBeforeSnapshot(persistenceId: String, maxSnapshotsToKeep: Int): Future[Option[SnapshotMetadata]] = {
     require(maxSnapshotsToKeep >= 1, "Must keep at least one snapshot")
-    val snapshots: Future[immutable.Seq[Row]] = selectLatestSnapshotsPs.futureResult().flatMap { ps =>
+    val snapshots: Future[Seq[Row]] = selectLatestSnapshotsPs.futureResult().flatMap { ps =>
       session.select(ps.bind(persistenceId, maxSnapshotsToKeep: JInt)).runWith(Sink.seq)
     }
     snapshots.flatMap(rows => issueSnapshotDelete(persistenceId, maxSnapshotsToKeep, rows))
@@ -241,7 +240,7 @@ final class Cleanup(systemProvider: ClassicActorSystemProvider, settings: Cleanu
    *
    * See single persistenceId overload for what is done for each persistence id
    */
-  def cleanupBeforeSnapshot(persistenceIds: immutable.Seq[String], nrSnapshotsToKeep: Int): Future[Done] = {
+  def cleanupBeforeSnapshot(persistenceIds: Seq[String], nrSnapshotsToKeep: Int): Future[Done] = {
     foreach(persistenceIds, "cleanupBeforeSnapshot", pid => cleanupBeforeSnapshot(pid, nrSnapshotsToKeep))
   }
 
@@ -251,7 +250,7 @@ final class Cleanup(systemProvider: ClassicActorSystemProvider, settings: Cleanu
    * See single persistenceId overload for what is done for each persistence id
    */
   def cleanupBeforeSnapshot(
-      persistenceIds: immutable.Seq[String],
+      persistenceIds: Seq[String],
       nrSnapshotsToKeep: Int,
       keepAfter: Long): Future[Done] = {
     foreach(persistenceIds, "cleanupBeforeSnapshot", pid => cleanupBeforeSnapshot(pid, nrSnapshotsToKeep, keepAfter))
@@ -268,7 +267,7 @@ final class Cleanup(systemProvider: ClassicActorSystemProvider, settings: Cleanu
    * Delete everything related to the given list of `persistenceIds`. All events, tagged events, and
    * snapshots are deleted.
    */
-  def deleteAll(persistenceIds: immutable.Seq[String], neverUsePersistenceIdAgain: Boolean): Future[Done] = {
+  def deleteAll(persistenceIds: Seq[String], neverUsePersistenceIdAgain: Boolean): Future[Done] = {
     foreach(persistenceIds, "deleteAll", pid => deleteAll(pid, neverUsePersistenceIdAgain))
   }
 
@@ -287,7 +286,7 @@ final class Cleanup(systemProvider: ClassicActorSystemProvider, settings: Cleanu
   /**
    * Delete all events related to the given list of `persistenceIds`. Snapshots are not deleted.
    */
-  def deleteAllEvents(persistenceIds: immutable.Seq[String], neverUsePersistenceIdAgain: Boolean): Future[Done] = {
+  def deleteAllEvents(persistenceIds: Seq[String], neverUsePersistenceIdAgain: Boolean): Future[Done] = {
     foreach(persistenceIds, "deleteAllEvents", pid => deleteAllEvents(pid, neverUsePersistenceIdAgain))
   }
 
@@ -302,7 +301,7 @@ final class Cleanup(systemProvider: ClassicActorSystemProvider, settings: Cleanu
    * Delete all events from `tag_views` table related to the given list of `persistenceIds`.
    * Events in `messages` (journal) table are not deleted and snapshots are not deleted.
    */
-  def deleteAllTaggedEvents(persistenceIds: immutable.Seq[String]): Future[Done] = {
+  def deleteAllTaggedEvents(persistenceIds: Seq[String]): Future[Done] = {
     foreach(persistenceIds, "deleteAllEvents", pid => deleteAllTaggedEvents(pid))
   }
 
@@ -329,7 +328,7 @@ final class Cleanup(systemProvider: ClassicActorSystemProvider, settings: Cleanu
   /**
    * Delete all snapshots related to the given list of `persistenceIds`. Events are not deleted.
    */
-  def deleteAllSnapshots(persistenceIds: immutable.Seq[String]): Future[Done] = {
+  def deleteAllSnapshots(persistenceIds: Seq[String]): Future[Done] = {
     foreach(persistenceIds, "deleteAllSnapshots", pid => deleteAllSnapshots(pid))
   }
 
@@ -341,7 +340,7 @@ final class Cleanup(systemProvider: ClassicActorSystemProvider, settings: Cleanu
   }
 
   private def foreach(
-      persistenceIds: immutable.Seq[String],
+      persistenceIds: Seq[String],
       operationName: String,
       pidOperation: String => Future[Done]): Future[Done] = {
     val size = persistenceIds.size

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournal.scala
@@ -43,8 +43,6 @@ import com.datastax.oss.protocol.internal.util.Bytes
 import com.typesafe.config.Config
 
 import scala.annotation.tailrec
-import scala.collection.immutable
-import scala.collection.immutable.Seq
 import scala.concurrent._
 import scala.jdk.CollectionConverters._
 import scala.jdk.FutureConverters._
@@ -353,7 +351,7 @@ import scala.util.{ Failure, Success, Try }
           if b.tags.isEmpty
         } yield b
 
-      val writesWithTags: immutable.Seq[TagWrite] = messagesByTag.map {
+      val writesWithTags: Seq[TagWrite] = messagesByTag.map {
         case (tag, writes) => TagWrite(tag, writes)
       }.toList
 

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/TagWriters.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/journal/TagWriters.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.persistence.cassandra.journal
 
-import scala.collection.immutable
 import scala.concurrent.Promise
 import java.lang.{ Integer => JInt, Long => JLong }
 import java.net.URLEncoder
@@ -129,7 +128,7 @@ import scala.util.Try
   /**
    * All tag writes should be for the same persistenceId
    */
-  private[pekko] case class BulkTagWrite(tagWrites: immutable.Seq[TagWrite], withoutTags: immutable.Seq[Serialized])
+  private[pekko] case class BulkTagWrite(tagWrites: Seq[TagWrite], withoutTags: Seq[Serialized])
       extends NoSerializationVerificationNeeded
 
   /**
@@ -138,7 +137,7 @@ import scala.util.Try
    * @param actorRunning migration sends these messages without the actor running so TagWriters should not
    *                     validate that the pid is running
    */
-  private[pekko] case class TagWrite(tag: Tag, serialised: immutable.Seq[Serialized], actorRunning: Boolean = true)
+  private[pekko] case class TagWrite(tag: Tag, serialised: Seq[Serialized], actorRunning: Boolean = true)
       extends NoSerializationVerificationNeeded
 
   def props(settings: TagWriterSettings, tagWriterSession: TagWritersSession): Props =
@@ -362,7 +361,7 @@ import scala.util.Try
     }
   }
 
-  private def updatePendingScanning(serialized: immutable.Seq[Serialized]): Unit = {
+  private def updatePendingScanning(serialized: Seq[Serialized]): Unit = {
     serialized.foreach { ser =>
       pendingScanning.get(ser.persistenceId) match {
         case Some(seqNr) =>

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -34,7 +34,6 @@ import pekko.util.OptionVal
 
 import java.lang.{ Long => JLong }
 import java.nio.ByteBuffer
-import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.jdk.FutureConverters._
 import scala.util.control.NonFatal
@@ -122,7 +121,7 @@ import scala.util.{ Failure, Success }
   }
 
   @nowarn("msg=match may not be exhaustive")
-  private def loadNAsync(metadata: immutable.Seq[SnapshotMetadata]): Future[Option[SelectedSnapshot]] = metadata match {
+  private def loadNAsync(metadata: Seq[SnapshotMetadata]): Future[Option[SelectedSnapshot]] = metadata match {
     case Seq()     => Future.successful(None) // no snapshots stored
     case md +: mds =>
       load1Async(md)
@@ -216,7 +215,7 @@ import scala.util.{ Failure, Success }
           // this meta query gets slower than slower if snapshots are deleted without a criteria.minSequenceNr as
           // all previous tombstones are scanned in the meta data query
           metadata(snapshotMetaPs, persistenceId, criteria, limit = None).flatMap {
-            (mds: immutable.Seq[SnapshotMetadata]) =>
+            (mds: Seq[SnapshotMetadata]) =>
               val boundStatementBatches = mds
                 .map(md =>
                   preparedDeleteSnapshot.map(_.bind(md.persistenceId, md.sequenceNr: JLong)
@@ -255,7 +254,7 @@ import scala.util.{ Failure, Success }
       snapshotMetaPs: PreparedStatement,
       persistenceId: String,
       criteria: SnapshotSelectionCriteria,
-      limit: Option[Int]): Future[immutable.Seq[SnapshotMetadata]] = {
+      limit: Option[Int]): Future[Seq[SnapshotMetadata]] = {
     val boundStmt = snapshotMetaPs
       .bind(persistenceId, criteria.maxSequenceNr: JLong, criteria.minSequenceNr: JLong)
       .setExecutionProfileName(snapshotSettings.readProfile)

--- a/core/src/multi-jvm/scala/org/apache/pekko/cluster/persistence/cassandra/MultiNodeClusterSpec.scala
+++ b/core/src/multi-jvm/scala/org/apache/pekko/cluster/persistence/cassandra/MultiNodeClusterSpec.scala
@@ -24,7 +24,6 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.exceptions.TestCanceledException
 import org.scalatest.{ Canceled, Outcome, Suite }
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.language.implicitConversions
 
@@ -261,7 +260,7 @@ trait MultiNodeClusterSpec extends Suite with STMultiNodeSpec with FlightRecordi
    * be determined from the `RoleName`.
    */
   def assertLeader(nodesInCluster: RoleName*): Unit =
-    if (nodesInCluster.contains(myself)) assertLeaderIn(nodesInCluster.to[immutable.Seq])
+    if (nodesInCluster.contains(myself)) assertLeaderIn(nodesInCluster)
 
   /**
    * Assert that the cluster has elected the correct leader
@@ -274,7 +273,7 @@ trait MultiNodeClusterSpec extends Suite with STMultiNodeSpec with FlightRecordi
    * member with status Up or Leaving and that information can't
    * be determined from the `RoleName`.
    */
-  def assertLeaderIn(nodesInCluster: immutable.Seq[RoleName]): Unit =
+  def assertLeaderIn(nodesInCluster: Seq[RoleName]): Unit =
     if (nodesInCluster.contains(myself)) {
       nodesInCluster.length should not be 0
       val expectedLeader = roleOfLeader(nodesInCluster)
@@ -324,7 +323,7 @@ trait MultiNodeClusterSpec extends Suite with STMultiNodeSpec with FlightRecordi
    * member with status Up or Leaving and that information can't
    * be determined from the `RoleName`.
    */
-  def roleOfLeader(nodesInCluster: immutable.Seq[RoleName] = roles): RoleName = {
+  def roleOfLeader(nodesInCluster: Seq[RoleName] = roles): RoleName = {
     nodesInCluster.length should not be 0
     nodesInCluster.sorted.head
   }

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraSpec.scala
@@ -37,7 +37,6 @@ import org.scalatest.{ Outcome, Suite }
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 import scala.annotation.nowarn
@@ -272,7 +271,7 @@ abstract class CassandraSpec(
       .run()
       .futureValue
 
-  def events(pid: String): immutable.Seq[Extractors.TaggedPersistentRepr] =
+  def events(pid: String): Seq[Extractors.TaggedPersistentRepr] =
     queries
       .eventsByPersistenceId(
         pid,
@@ -287,7 +286,7 @@ abstract class CassandraSpec(
       .run()
       .futureValue
 
-  def eventPayloadsWithTags(pid: String): immutable.Seq[(Any, Set[String])] =
+  def eventPayloadsWithTags(pid: String): Seq[(Any, Set[String])] =
     queries
       .eventsByPersistenceId(
         pid,

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/EventsByTagStressSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/EventsByTagStressSpec.scala
@@ -20,7 +20,6 @@ import pekko.persistence.query.NoOffset
 import pekko.stream.testkit.TestSubscriber
 import pekko.stream.testkit.scaladsl.TestSink
 
-import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 
 class EventsByTagStressSpec extends CassandraSpec(s"""
@@ -44,7 +43,7 @@ class EventsByTagStressSpec extends CassandraSpec(s"""
         system.actorOf(TestActor.props(s"pid$i"))
       }
 
-      val eventsByTagQueries: immutable.Seq[(Int, TestSubscriber.Probe[(String, Int)])] = (0 until readers).map { i =>
+      val eventsByTagQueries: Seq[(Int, TestSubscriber.Probe[(String, Int)])] = (0 until readers).map { i =>
         val probe = queryJournal
           .eventsByTag("all", NoOffset)
           .map(i => {

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournalDeletionSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/journal/CassandraJournalDeletionSpec.scala
@@ -18,7 +18,6 @@ import pekko.actor.{ ActorRef, PoisonPill, Props }
 import pekko.persistence.{ DeleteMessagesFailure, DeleteMessagesSuccess, PersistentActor, RecoveryCompleted }
 import pekko.persistence.cassandra.CassandraSpec
 import pekko.testkit.TestProbe
-import scala.collection.immutable
 import scala.concurrent.duration._
 
 import pekko.testkit.EventFilter
@@ -165,7 +164,7 @@ class CassandraJournalDeletionSpec extends CassandraSpec(s"""
       msg.getMessage shouldEqual "Over 5 outstanding deletes for persistenceId p2"
 
       // Does't matter how many as long as they are all in order
-      val successes: immutable.Seq[Long] = deleteSuccess.receiveWhile(max = 100.millis) {
+      val successes: Seq[Long] = deleteSuccess.receiveWhile(max = 100.millis) {
         case Deleted(i) => i
       }
       successes shouldEqual successes.sorted

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/query/TestActor.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/query/TestActor.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.persistence.cassandra.query
 
-import scala.collection.immutable
 import org.apache.pekko
 import pekko.actor.Props
 import pekko.persistence.PersistentActor
@@ -25,7 +24,7 @@ object TestActor {
   def props(persistenceId: String, journalId: String = "pekko.persistence.cassandra.journal"): Props =
     Props(new TestActor(persistenceId, journalId))
 
-  final case class PersistAll(events: immutable.Seq[String])
+  final case class PersistAll(events: Seq[String])
   final case class DeleteTo(seqNr: Long)
 }
 

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
@@ -28,8 +28,6 @@ import pekko.testkit.TestProbe
 import com.datastax.oss.driver.api.core.cql.SimpleStatement
 import com.typesafe.config.ConfigFactory
 
-import scala.collection.immutable.Seq
-
 object CassandraSnapshotStoreConfiguration {
   lazy val config = ConfigFactory.parseString(s"""
        pekko.persistence.cassandra.journal.keyspace=CassandraSnapshotStoreSpec


### PR DESCRIPTION
### Motivation
The codebase still carried Scala 2.12-era `immutable.Seq` qualifiers, which are redundant on Scala 2.13/3 where `scala.Seq` is already an alias for `scala.collection.immutable.Seq`. This is the equivalent of apache/pekko#3539 for this repo.

### Modification
- Replace `immutable.Seq` with `Seq` across 11 files and drop the now-unused `scala.collection.immutable` / `scala.collection.immutable.Seq` imports. Same erasure, so this is source- and binary-compatible.
- `MultiNodeClusterSpec.assertLeader`: pass the varargs `Seq` straight through to `assertLeaderIn` instead of `.to[immutable.Seq]` (varargs are already `immutable.Seq` on 2.13/3).
- `immutable.Iterable` in `CassandraReadJournal` and `immutable.Queue` in `AllPersistenceIdsStage` are intentionally left as-is; those have no `scala.` alias.

Pure refactor with no behaviour change, so no new directional test is added (same as the upstream PR); the existing suites exercise every touched signature.

### Result
No remaining Scala 2.12 collection idioms in main, test or multi-jvm sources.

### Tests
- native `scalafmt --mode diff-ref=upstream/main`: clean
- `sbt "+core/Test/compile"` (2.13.18 and 3.3.8): passes after a clean build
- `sbt core/mimaReportBinaryIssues` on 2.13.18 and 3.3.8: no issues
- `sbt checkCodeStyle`: passes
- `git diff --check`: clean
- `core/MultiJvm/compile` already fails on `main` for unrelated reasons (missing `pekko.remote.testkit.FlightRecordingSupport`, `CassandraContainer` no longer takes type params, `ClusterReadView.refreshCurrentState`), so the multi-jvm change is not compile-verified locally
- Cassandra-backed test suites not run locally (no Docker available); relying on CI

### References
None - equivalent of apache/pekko#3539
